### PR TITLE
chore: enable build-time lint and ts checks

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,13 +1,19 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   eslint: {
-    ignoreDuringBuilds: true,
+    ignoreDuringBuilds: false,
   },
   typescript: {
-    ignoreBuildErrors: true,
+    ignoreBuildErrors: false,
   },
   images: {
-    unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'hebbkx1anhila5yf.public.blob.vercel-storage.com',
+        pathname: '/**',
+      },
+    ],
   },
 }
 


### PR DESCRIPTION
## Summary
- enforce lint and TypeScript errors during build
- optimize remote images via Next.js `remotePatterns`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6896986a593c8330bff75c7cff673cd6