### PR TITLE
feat: centralize site metadata and localize layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,77 +1,77 @@
 import type { Metadata, Viewport } from 'next';
 import './globals.css';
+import { siteConfig } from '@/lib/config';
 
 export const metadata: Metadata = {
-	title: {
-		default: 'Trust Access | Identity & Access Management',
-		template: '%s | Trust Access',
-	},
-	description:
-		'Trust Access is a cybersecurity consultancy specialized in authentication, identity, and access management (IAM). Secure, automate, and scale access for your business.',
-	applicationName: 'Trust Access',
-	generator: 'Next.js',
-	keywords: [
-		'Identity and Access Management',
-		'IAM',
-		'Cybersecurity',
-		'Authentication',
-		'Governance',
-		'MFA',
-		'SSO',
-		'Trust Access',
-	],
-	metadataBase: new URL('https://www.trustaccess.com.br'),
-	openGraph: {
-		title: 'Trust Access | Identity & Access Management',
-		description:
-			'Secure, automate, and scale identity and access for your organization.',
-		url: 'https://www.trustaccess.com.br',
-		siteName: 'Trust Access',
-		images: [
-			{
-				url: 'https://www.trustaccess.com.br/og-image.jpg',
-				width: 1200,
-				height: 630,
-				alt: 'Trust Access',
-			},
-		],
-		locale: 'en_US',
-		type: 'website',
-	},
-	twitter: {
-		card: 'summary_large_image',
-		title: 'Trust Access | Identity & Access Management',
-		description:
-			'Secure, automate, and scale identity and access for your organization.',
-		images: ['https://www.trustaccess.com.br/og-image.jpg'],
-	},
-	icons: {
-		icon: '/favicon.ico',
-		shortcut: '/favicon.ico',
-		apple: '/apple-touch-icon.png',
-	},
-	manifest: '/site.webmanifest',
-	robots: {
-		index: true,
-		follow: true,
-	},
-	category: 'Technology',
+  title: {
+    default: `${siteConfig.name} | Identity & Access Management`,
+    template: `%s | ${siteConfig.name}`,
+  },
+  description: `${siteConfig.name} is a cybersecurity consultancy specialized in authentication, identity, and access management (IAM). Secure, automate, and scale access for your business.`,
+  applicationName: siteConfig.name,
+  generator: 'Next.js',
+  keywords: [
+    'Identity and Access Management',
+    'IAM',
+    'Cybersecurity',
+    'Authentication',
+    'Governance',
+    'MFA',
+    'SSO',
+    siteConfig.name,
+  ],
+  metadataBase: new URL(siteConfig.url),
+  openGraph: {
+    title: `${siteConfig.name} | Identity & Access Management`,
+    description:
+      'Secure, automate, and scale identity and access for your organization.',
+    url: siteConfig.url,
+    siteName: siteConfig.name,
+    images: [
+      {
+        url: siteConfig.ogImage,
+        width: 1200,
+        height: 630,
+        alt: siteConfig.name,
+      },
+    ],
+    locale: 'pt_BR',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${siteConfig.name} | Identity & Access Management`,
+    description:
+      'Secure, automate, and scale identity and access for your organization.',
+    images: [siteConfig.ogImage],
+  },
+  icons: {
+    icon: '/favicon.ico',
+    shortcut: '/favicon.ico',
+    apple: '/apple-touch-icon.png',
+  },
+  manifest: '/site.webmanifest',
+  robots: {
+    index: true,
+    follow: true,
+  },
+  category: 'Technology',
 };
 
 export const viewport: Viewport = {
-	width: 'device-width',
-	initialScale: 1,
-	themeColor: '#0A0A0A',
+  width: 'device-width',
+  initialScale: 1,
+  themeColor: '#0A0A0A',
 };
 
 export default function RootLayout({
-	children,
+  children,
 }: {
-	children: React.ReactNode;
+  children: React.ReactNode;
 }) {
-	return (
-		<html lang='en'>
-			<body>{children}</body>
-		</html>
-	);
+  return (
+    <html lang='pt-BR'>
+      <body>{children}</body>
+    </html>
+  );
 }

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -1,0 +1,7 @@
+export const siteConfig = {
+  name: 'Trust Access',
+  url: 'https://www.trustaccess.com.br',
+  ogImage: 'https://www.trustaccess.com.br/og-image.jpg',
+};
+
+export type SiteConfig = typeof siteConfig;


### PR DESCRIPTION
## Summary
- set document language to pt-BR
- centralize site metadata like name and URLs in a shared config module

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6897299efe508330ad059bce36727853