### PR TITLE
feat: use next/font for global typography

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -3,10 +3,6 @@
 @tailwind components;
 @tailwind utilities;
 
-body {
-	font-family: Arial, Helvetica, sans-serif;
-}
-
 @layer utilities {
 	.text-balance {
 		text-wrap: balance;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,9 @@
 import type { Metadata, Viewport } from 'next';
+import { Inter } from 'next/font/google';
 import './globals.css';
 import { siteConfig } from '@/lib/config';
+
+const inter = Inter({ subsets: ['latin'] });
 
 export const metadata: Metadata = {
   title: {
@@ -71,7 +74,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang='pt-BR'>
-      <body>{children}</body>
+      <body className={inter.className}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- import Inter from `next/font/google` and apply to `<body>`
- remove manual `font-family` from global stylesheet

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68972ca02c708330968c0929bbd8faef