### PR TITLE
feat: integrate react query for data fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Esta home page foi desenvolvida para apresentar os serviços da Trust Access de 
 - **Formulários Validados**: Validação client-side completa
 - **Imagens Otimizadas**: Next.js Image component para performance
 - **TypeScript**: Tipagem completa para maior confiabilidade
+- **React Query**: Gerenciamento de dados e cache assíncrono
 
 ## 🛠️ Stack Tecnológica
 
@@ -50,6 +51,7 @@ Esta home page foi desenvolvida para apresentar os serviços da Trust Access de 
 | **shadcn/ui**    | Latest | Componentes UI acessíveis e customizáveis |
 | **Lucide React** | Latest | Biblioteca de ícones moderna              |
 | **Radix UI**     | Latest | Primitivos UI headless                    |
+| **React Query**  | Latest | Gerenciamento de dados assíncronos       |
 
 ## 📦 Instalação e Configuração
 
@@ -101,8 +103,11 @@ ta-home-page/
 │   ├── layout.tsx         # Layout principal
 │   └── page.tsx           # Página principal
 ├── components/            # Componentes reutilizáveis
+│   ├── query-provider.tsx # Provedor do React Query
 │   └── ui/               # Componentes shadcn/ui
 ├── lib/                  # Utilitários e configurações
+│   ├── api/              # Configurações de API
+│   │   └── queryClient.ts # Cliente do React Query
 │   └── utils.ts          # Funções auxiliares
 ├── public/               # Arquivos estáticos
 │   └── images/           # Imagens e logos
@@ -140,6 +145,29 @@ Todos os componentes UI estão em `components/ui/` e podem ser customizados:
 ```bash
 # Adicionar novos componentes shadcn/ui
 npx shadcn@latest add [component-name]
+```
+
+## 🔄 React Query
+
+A biblioteca **React Query** está configurada globalmente para facilitar o consumo de APIs e o cache de dados.
+
+- O `QueryClient` está definido em `lib/api/queryClient.ts`.
+- O componente `QueryProvider` envolve a aplicação em `app/layout.tsx`.
+
+Exemplo de uso:
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+
+function Example() {
+  const { data, isLoading } = useQuery({
+    queryKey: ['usuarios'],
+    queryFn: () => fetch('/api/users').then((res) => res.json()),
+  });
+
+  if (isLoading) return <span>Carregando...</span>;
+  return <pre>{JSON.stringify(data)}</pre>;
+}
 ```
 
 ## 🚀 Deploy

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { siteConfig } from '@/lib/config';
+import { QueryProvider } from '@/components/query-provider';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -74,7 +75,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang='pt-BR'>
-      <body className={inter.className}>{children}</body>
+      <body className={inter.className}>
+        <QueryProvider>{children}</QueryProvider>
+      </body>
     </html>
   );
 }

--- a/components/query-provider.tsx
+++ b/components/query-provider.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryClient } from '@/lib/api/queryClient';
+
+export function QueryProvider({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/lib/api/queryClient.ts
+++ b/lib/api/queryClient.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-toggle": "1.1.1",
     "@radix-ui/react-toggle-group": "1.1.1",
     "@radix-ui/react-tooltip": "1.1.6",
+    "@tanstack/react-query": "^5.84.2",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -92,6 +92,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.1.6
         version: 1.1.6(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@tanstack/react-query':
+        specifier: ^5.84.2
+        version: 5.84.2(react@19.1.1)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.21(postcss@8.5.6)
@@ -1439,6 +1442,14 @@ packages:
 
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@tanstack/query-core@5.83.1':
+    resolution: {integrity: sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==}
+
+  '@tanstack/react-query@5.84.2':
+    resolution: {integrity: sha512-cZadySzROlD2+o8zIfbD978p0IphuQzRWiiH3I2ugnTmz4jbjc0+TdibpwqxlzynEen8OulgAg+rzdNF37s7XQ==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -4847,6 +4858,13 @@ snapshots:
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
+
+  '@tanstack/query-core@5.83.1': {}
+
+  '@tanstack/react-query@5.84.2(react@19.1.1)':
+    dependencies:
+      '@tanstack/query-core': 5.83.1
+      react: 19.1.1
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## Summary
- install and configure @tanstack/react-query
- wrap root layout with QueryProvider using a shared QueryClient
- document React Query usage patterns

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6897383a52fc83308d067a9e68a04927