### PR TITLE
feat: add basic i18n support

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import type { Metadata, Viewport } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { siteConfig } from '@/lib/config';
 import { QueryProvider } from '@/components/query-provider';
+import { I18nProvider, Locale } from '@/lib/i18n';
+import { useState } from 'react';
 
 const inter = Inter({ subsets: ['latin'] });
 
@@ -73,10 +77,14 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const [locale, setLocale] = useState<Locale>('pt');
+
   return (
-    <html lang='pt-BR'>
+    <html lang={locale}>
       <body className={inter.className}>
-        <QueryProvider>{children}</QueryProvider>
+        <I18nProvider locale={locale} setLocale={setLocale}>
+          <QueryProvider>{children}</QueryProvider>
+        </I18nProvider>
       </body>
     </html>
   );

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import { Button } from '@/components/ui/button';
 import { Menu } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { navItems } from '@/data/navigation';
+import LanguageSwitcher from './language-switcher';
+import { useI18n } from '@/lib/i18n';
 
 export default function Header() {
+  const { t } = useI18n();
   return (
     <header className='sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60'>
       <div className='container flex h-16 items-center justify-between px-4 md:px-6'>
@@ -28,16 +33,17 @@ export default function Header() {
               href={href}
               className='text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors'
             >
-              {label}
+              {t(label)}
             </Link>
           ))}
         </nav>
         <div className='flex items-center space-x-4'>
+          <LanguageSwitcher />
           <Button variant='ghost' className='hidden md:inline-flex'>
-            Login
+            {t('header.login')}
           </Button>
           <Button className='bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700'>
-            Book a Demo
+            {t('header.bookDemo')}
           </Button>
           <Button variant='ghost' size='icon' className='md:hidden'>
             <Menu className='h-5 w-5' />

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -1,6 +1,10 @@
+"use client";
+
 import { Button } from '@/components/ui/button';
+import { useI18n } from '@/lib/i18n';
 
 export default function Hero() {
+  const { t } = useI18n();
   return (
     <section className='relative py-20 md:py-32 overflow-hidden'>
       {/* Geometric Background Pattern */}
@@ -25,26 +29,26 @@ export default function Hero() {
       <div className='container relative px-4 md:px-6'>
         <div className='max-w-4xl'>
           <div className='space-y-8'>
-            <h1 className='text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl text-gray-900'>
-              IAM e Segurança como Serviço para{' '}
-              <span className='bg-gradient-to-r from-teal-500 to-blue-600 bg-clip-text text-transparent'>
-                Operações Seguras
-              </span>
-            </h1>
-            <p className='text-xl text-gray-600 max-w-3xl leading-relaxed'>
-              Capacitamos empresas com soluções completas de IAM e CIAM, unindo autenticação, governança e segurança de aplicações e APIs. Garantimos controle de acesso eficiente, com foco em proteção e boa experiência do usuário.
-            </p>
-            <p className='text-lg text-gray-700 max-w-3xl leading-relaxed'>
-              Oferecemos integrações, automação de onboarding/offboarding, suporte técnico e treinamentos. Operações mais seguras, ágeis e alinhadas com as exigências atuais de segurança digital.
-            </p>
-            <div className='pt-4'>
-              <Button
-                size='lg'
-                className='bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700 text-lg px-8 py-6 rounded-full'
-              >
-                Agendar Demo
-              </Button>
-            </div>
+              <h1 className='text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl text-gray-900'>
+                {t('hero.title')}{' '}
+                <span className='bg-gradient-to-r from-teal-500 to-blue-600 bg-clip-text text-transparent'>
+                  {t('hero.highlight')}
+                </span>
+              </h1>
+              <p className='text-xl text-gray-600 max-w-3xl leading-relaxed'>
+                {t('hero.description1')}
+              </p>
+              <p className='text-lg text-gray-700 max-w-3xl leading-relaxed'>
+                {t('hero.description2')}
+              </p>
+              <div className='pt-4'>
+                <Button
+                  size='lg'
+                  className='bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700 text-lg px-8 py-6 rounded-full'
+                >
+                  {t('hero.cta')}
+                </Button>
+              </div>
           </div>
         </div>
       </div>

--- a/components/language-switcher.tsx
+++ b/components/language-switcher.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { Locale, useI18n } from '@/lib/i18n';
+
+export default function LanguageSwitcher() {
+  const { locale, setLocale } = useI18n();
+  return (
+    <select
+      className='border rounded px-2 py-1 text-sm'
+      value={locale}
+      onChange={(e) => setLocale(e.target.value as Locale)}
+    >
+      <option value='en'>EN</option>
+      <option value='es'>ES</option>
+      <option value='pt'>PT</option>
+    </select>
+  );
+}

--- a/data/navigation.ts
+++ b/data/navigation.ts
@@ -1,7 +1,7 @@
 export const navItems = [
-  { href: '#services', label: 'Services' },
-  { href: '#solutions', label: 'Solutions' },
-  { href: '#cases', label: 'Cases' },
-  { href: '#portfolio', label: 'Portfolio' },
-  { href: '#contact', label: 'Contact' },
+  { href: '#services', label: 'nav.services' },
+  { href: '#solutions', label: 'nav.solutions' },
+  { href: '#cases', label: 'nav.cases' },
+  { href: '#portfolio', label: 'nav.portfolio' },
+  { href: '#contact', label: 'nav.contact' },
 ];

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -1,0 +1,20 @@
+{
+  "nav": {
+    "services": "Services",
+    "solutions": "Solutions",
+    "cases": "Cases",
+    "portfolio": "Portfolio",
+    "contact": "Contact"
+  },
+  "header": {
+    "login": "Login",
+    "bookDemo": "Book a Demo"
+  },
+  "hero": {
+    "title": "IAM & Security as a Service for",
+    "highlight": "Secure Operations",
+    "description1": "We empower companies with complete IAM and CIAM solutions, combining authentication, governance and application and API security. We ensure efficient access control with focus on protection and a great user experience.",
+    "description2": "We offer integrations, onboarding/offboarding automation, technical support and training. Safer, more agile operations aligned with today's digital security requirements.",
+    "cta": "Schedule Demo"
+  }
+}

--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -1,0 +1,20 @@
+{
+  "nav": {
+    "services": "Servicios",
+    "solutions": "Soluciones",
+    "cases": "Casos",
+    "portfolio": "Portafolio",
+    "contact": "Contacto"
+  },
+  "header": {
+    "login": "Iniciar sesión",
+    "bookDemo": "Reservar una demo"
+  },
+  "hero": {
+    "title": "IAM y Seguridad como Servicio para",
+    "highlight": "Operaciones Seguras",
+    "description1": "Capacitamos empresas con soluciones completas de IAM y CIAM, uniendo autenticación, gobernanza y seguridad de aplicaciones y API. Garantizamos control de acceso eficiente, enfocado en protección y una buena experiencia de usuario.",
+    "description2": "Ofrecemos integraciones, automatización de onboarding/offboarding, soporte técnico y capacitaciones. Operaciones más seguras, ágiles y alineadas con las exigencias actuales de seguridad digital.",
+    "cta": "Programar Demo"
+  }
+}

--- a/lib/i18n/index.tsx
+++ b/lib/i18n/index.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+export type Locale = 'en' | 'es' | 'pt';
+
+interface I18nContextProps {
+  t: (key: string) => string;
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}
+
+const I18nContext = createContext<I18nContextProps>({
+  t: (key: string) => key,
+  locale: 'en',
+  setLocale: () => {},
+});
+
+function getValue(dict: Record<string, unknown>, key: string): string | undefined {
+  return key
+    .split('.')
+    .reduce(
+      (acc: unknown, part) =>
+        acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[part] : undefined,
+      dict,
+    ) as string | undefined;
+}
+
+const loaders: Record<Locale, () => Promise<{ default: Record<string, unknown> }>> = {
+  en: () => import('./en.json'),
+  es: () => import('./es.json'),
+  pt: () => import('./pt.json'),
+};
+
+export function I18nProvider({
+  children,
+  locale,
+  setLocale,
+}: {
+  children: React.ReactNode;
+  locale: Locale;
+  setLocale: (locale: Locale) => void;
+}) {
+  const [dictionary, setDictionary] = useState<Record<string, unknown>>({});
+
+  useEffect(() => {
+    loaders[locale]().then((module) => setDictionary(module.default));
+    document.documentElement.lang = locale;
+  }, [locale]);
+
+  function t(key: string) {
+    return getValue(dictionary, key) || key;
+  }
+
+  return (
+    <I18nContext.Provider value={{ t, locale, setLocale }}>
+      {children}
+    </I18nContext.Provider>
+  );
+}
+
+export function useI18n() {
+  return useContext(I18nContext);
+}

--- a/lib/i18n/pt.json
+++ b/lib/i18n/pt.json
@@ -1,0 +1,20 @@
+{
+  "nav": {
+    "services": "Serviços",
+    "solutions": "Soluções",
+    "cases": "Cases",
+    "portfolio": "Portfólio",
+    "contact": "Contato"
+  },
+  "header": {
+    "login": "Entrar",
+    "bookDemo": "Agendar Demo"
+  },
+  "hero": {
+    "title": "IAM e Segurança como Serviço para",
+    "highlight": "Operações Seguras",
+    "description1": "Capacitamos empresas com soluções completas de IAM e CIAM, unindo autenticação, governança e segurança de aplicações e APIs. Garantimos controle de acesso eficiente, com foco em proteção e boa experiência do usuário.",
+    "description2": "Oferecemos integrações, automação de onboarding/offboarding, suporte técnico e treinamentos. Operações mais seguras, ágeis e alinhadas com as exigências atuais de segurança digital.",
+    "cta": "Agendar Demo"
+  }
+}


### PR DESCRIPTION
## Summary
- add locale dictionaries for English, Spanish and Portuguese
- create i18n provider and language switcher
- replace hardcoded strings in header and hero with translations

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68973e79f8788330a09fa48d769053f2