### PR TITLE
refactor: externalize hard-coded text into i18n

### DIFF
--- a/components/atoms/language-switcher.tsx
+++ b/components/atoms/language-switcher.tsx
@@ -3,16 +3,16 @@
 import { Locale, useI18n } from '@/lib/i18n';
 
 export default function LanguageSwitcher() {
-  const { locale, setLocale } = useI18n();
+  const { t, locale, setLocale } = useI18n();
   return (
     <select
       className='border rounded px-2 py-1 text-sm'
       value={locale}
       onChange={(e) => setLocale(e.target.value as Locale)}
     >
-      <option value='en'>EN</option>
-      <option value='es'>ES</option>
-      <option value='pt'>PT</option>
+      <option value='en'>{t('languages.en')}</option>
+      <option value='es'>{t('languages.es')}</option>
+      <option value='pt'>{t('languages.pt')}</option>
     </select>
   );
 }

--- a/components/organisms/audit-section.tsx
+++ b/components/organisms/audit-section.tsx
@@ -1,8 +1,10 @@
 import { Button } from '@/components/atoms/ui/button';
 import Image from 'next/image';
 import { BLUR_PLACEHOLDER } from '@/lib/blur';
+import { useI18n } from '@/lib/i18n';
 
 export default function AuditSection() {
+  const { t } = useI18n();
   return (
     <section className='py-20 md:py-32'>
       <div className='container px-4 md:px-6'>
@@ -10,10 +12,10 @@ export default function AuditSection() {
           <div className='space-y-8'>
             <div className='space-y-6'>
               <h3 className='text-3xl font-bold text-gray-900'>
-                Auditar e Controlar o Fluxo de Dados Dentro e Fora da Sua Organização
+                {t('audit.title')}
               </h3>
               <p className='text-lg text-gray-600 leading-relaxed'>
-                Proteja dados em movimento, seja um e-mail de entrada ou uma mensagem de saída, ou uma página de sistema interno. Com a Trust Access, você pode alterar ou revogar permissões de acesso a qualquer momento.
+                {t('audit.description')}
               </p>
             </div>
           </div>
@@ -21,7 +23,7 @@ export default function AuditSection() {
             <div className='bg-gradient-to-br from-purple-100 via-pink-50 to-purple-100 rounded-3xl p-8 relative overflow-hidden'>
               <Image
                 src='/placeholder.svg?height=400&width=600'
-                alt='Data audit and control'
+                alt={t('audit.imageAlt')}
                 width={600}
                 height={400}
                 className='rounded-lg shadow-lg'
@@ -32,7 +34,7 @@ export default function AuditSection() {
               {/* Mock Email Interface Overlay */}
               <div className='absolute top-8 right-8 bg-white rounded-lg shadow-xl p-4 w-72'>
                 <div className='flex items-center space-x-2 mb-4'>
-                  <div className='text-sm font-medium text-blue-600'>Para</div>
+                  <div className='text-sm font-medium text-blue-600'>{t('common.to')}</div>
                   <div className='flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1'>
                     <div className='w-6 h-6 bg-gray-400 rounded-full'></div>
                     <span className='text-sm'>admin@empresa.com.br</span>
@@ -42,7 +44,7 @@ export default function AuditSection() {
                   </div>
                 </div>
                 <div className='flex items-center space-x-2 mb-6'>
-                  <div className='text-sm font-medium text-gray-600'>De</div>
+                  <div className='text-sm font-medium text-gray-600'>{t('common.from')}</div>
                   <div className='flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1'>
                     <div className='w-6 h-6 bg-green-500 rounded-full'></div>
                     <span className='text-sm'>contato@trustaccess.com.br</span>
@@ -54,7 +56,7 @@ export default function AuditSection() {
                 <div className='bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-4'>
                   <Image
                     src='/placeholder.svg?height=200&width=250'
-                    alt='Email content preview'
+                    alt={t('audit.emailAlt')}
                     width={250}
                     height={200}
                     className='rounded-lg w-full'
@@ -63,9 +65,9 @@ export default function AuditSection() {
                     blurDataURL={BLUR_PLACEHOLDER}
                   />
                   <div className='mt-4 flex items-center justify-between'>
-                    <span className='text-sm font-medium text-blue-700'>Proteção</span>
+                    <span className='text-sm font-medium text-blue-700'>{t('common.protection')}</span>
                     <div className='flex items-center space-x-2'>
-                      <span className='text-xs text-blue-600'>ON</span>
+                      <span className='text-xs text-blue-600'>{t('common.on')}</span>
                       <div className='w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>

--- a/components/organisms/audit-section.tsx
+++ b/components/organisms/audit-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from '@/components/atoms/ui/button';
 import Image from 'next/image';
 import { BLUR_PLACEHOLDER } from '@/lib/blur';

--- a/components/organisms/clients-section.tsx
+++ b/components/organisms/clients-section.tsx
@@ -1,13 +1,15 @@
 import { Card, CardContent } from '@/components/atoms/ui/card';
 import Image from 'next/image';
 import { clientCases } from '@/data/client-cases';
+import { useI18n } from '@/lib/i18n';
 
 export default function ClientsSection() {
+  const { t } = useI18n();
   return (
     <section className='py-20 md:py-32 bg-white'>
       <div className='container max-w-screen-xl mx-auto px-4 md:px-6'>
         <h2 className='text-3xl md:text-5xl font-bold text-center mb-16 text-gray-900'>
-          Clientes reais. Sucessos reais. Comprovados.
+          {t('clients.heading')}
         </h2>
         <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6'>
           {clientCases.map(({ img, title, heading, desc }, idx) => (

--- a/components/organisms/clients-section.tsx
+++ b/components/organisms/clients-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Card, CardContent } from '@/components/atoms/ui/card';
 import Image from 'next/image';
 import { clientCases } from '@/data/client-cases';

--- a/components/organisms/compliance-section.tsx
+++ b/components/organisms/compliance-section.tsx
@@ -2,8 +2,10 @@ import { Button } from '@/components/atoms/ui/button';
 import { Checkbox } from '@/components/atoms/ui/checkbox';
 import Image from 'next/image';
 import { BLUR_PLACEHOLDER } from '@/lib/blur';
+import { useI18n } from '@/lib/i18n';
 
 export default function ComplianceSection() {
+  const { t } = useI18n();
   return (
     <section className='py-20 md:py-32 bg-gray-50'>
       <div className='container px-4 md:px-6'>
@@ -12,7 +14,7 @@ export default function ComplianceSection() {
             <div className='bg-gradient-to-br from-teal-100 via-blue-100 to-cyan-100 rounded-3xl p-8 relative overflow-hidden'>
               <Image
                 src='/placeholder.svg?height=400&width=600'
-                alt='Professional working on compliance'
+                alt={t('compliance.imageAlt')}
                 width={600}
                 height={400}
                 className='rounded-lg shadow-lg'
@@ -27,7 +29,7 @@ export default function ComplianceSection() {
                     <span className='text-white text-xs'>PDF</span>
                   </div>
                   <div className='flex-1'>
-                    <div className='text-sm font-medium'>Relatório Trimestral</div>
+                    <div className='text-sm font-medium'>{t('compliance.reportTitle')}</div>
                     <div className='text-xs text-gray-500'>Empresa.pdf.tdf</div>
                   </div>
                   <Button size='sm' variant='ghost'>
@@ -36,36 +38,36 @@ export default function ComplianceSection() {
                 </div>
                 <div className='space-y-2 text-xs'>
                   <div className='flex justify-between'>
-                    <span className='text-gray-600'>Aberto</span>
-                    <span>5:05 PM por mim</span>
+                    <span className='text-gray-600'>{t('compliance.open')}</span>
+                    <span>{t('compliance.openedByMe')}</span>
                   </div>
                   <div className='flex justify-between'>
-                    <span className='text-gray-600'>Criado</span>
-                    <span>5:05 PM com Trust Access para Drive</span>
+                    <span className='text-gray-600'>{t('compliance.created')}</span>
+                    <span>{t('compliance.createdWith')}</span>
                   </div>
                 </div>
                 <div className='mt-4 pt-3 border-t'>
                   <div className='space-y-2'>
                     <div className='flex items-center space-x-2'>
                       <Checkbox checked />
-                      <span className='text-xs'>Desabilitar re-compartilhamento</span>
+                      <span className='text-xs'>{t('compliance.disableResharing')}</span>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Checkbox checked />
-                      <span className='text-xs'>Marca d&apos;água</span>
+                      <span className='text-xs'>{t('common.watermark')}</span>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Checkbox checked />
-                      <span className='text-xs'>Data de expiração (clique para redefinir)</span>
+                      <span className='text-xs'>{t('compliance.expirationNote')}</span>
                     </div>
                   </div>
                   <div className='text-xs text-gray-500 mt-2'>16 de fevereiro, 2023 1:45 PM</div>
                   <div className='mt-3 pt-2 border-t'>
                     <div className='flex items-center space-x-1 text-red-600 text-xs'>
                       <span className='w-2 h-2 bg-red-500 rounded-full'></span>
-                      <span>Revogar Acesso de todos os Convidados</span>
+                      <span>{t('compliance.revokeAccess')}</span>
                     </div>
-                    <div className='mt-2 text-xs font-medium'>Usuários Permitidos (3)</div>
+                    <div className='mt-2 text-xs font-medium'>{t('compliance.allowedUsers')}</div>
                     <div className='space-y-1 mt-1'>
                       <div className='flex items-center space-x-2'>
                         <div className='w-4 h-4 bg-gray-300 rounded-full'></div>
@@ -78,7 +80,7 @@ export default function ComplianceSection() {
                       <div className='flex items-center space-x-2'>
                         <div className='w-4 h-4 bg-blue-500 rounded-full'></div>
                         <span className='text-xs'>contato@trustaccess.com.br</span>
-                        <span className='text-xs text-blue-600'>Acessado 12 minutos atrás</span>
+                        <span className='text-xs text-blue-600'>{t('compliance.accessed')}</span>
                       </div>
                     </div>
                   </div>
@@ -88,9 +90,9 @@ export default function ComplianceSection() {
           </div>
           <div className='space-y-8'>
             <div className='space-y-6'>
-              <h3 className='text-3xl font-bold text-gray-900'>Fortalecer Conformidade</h3>
+              <h3 className='text-3xl font-bold text-gray-900'>{t('compliance.title')}</h3>
               <p className='text-lg text-gray-600 leading-relaxed'>
-                Seja você do setor financeiro, manufatura, educação ou saúde, a criptografia e controles de acesso da Trust Access suportam até mesmo as regulamentações mais rigorosas, incluindo LGPD, GDPR, ISO 27001, SOC 2, e muitas outras.
+                {t('compliance.description')}
               </p>
             </div>
           </div>

--- a/components/organisms/compliance-section.tsx
+++ b/components/organisms/compliance-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from '@/components/atoms/ui/button';
 import { Checkbox } from '@/components/atoms/ui/checkbox';
 import Image from 'next/image';

--- a/components/organisms/footer.tsx
+++ b/components/organisms/footer.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Globe, Linkedin, Mail } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';

--- a/components/organisms/footer.tsx
+++ b/components/organisms/footer.tsx
@@ -1,8 +1,10 @@
 import { Globe, Linkedin, Mail } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useI18n } from '@/lib/i18n';
 
 export default function Footer() {
+  const { t } = useI18n();
   return (
     <footer className='bg-gray-900 text-white py-12'>
       <div className='container px-4 md:px-6'>
@@ -22,7 +24,7 @@ export default function Footer() {
               </span>
             </div>
             <p className='text-gray-400 max-w-xs'>
-              Especialistas em IAM e segurança digital. Implementamos soluções robustas de gestão de identidades e acessos.
+              {t('footer.tagline')}
             </p>
             <div className='flex space-x-4'>
               <Link href='#' className='text-gray-400 hover:text-white transition-colors'>
@@ -37,41 +39,41 @@ export default function Footer() {
             </div>
           </div>
           <div className='space-y-4'>
-            <h3 className='text-lg font-semibold'>Serviços</h3>
+            <h3 className='text-lg font-semibold'>{t('footer.services')}</h3>
             <div className='space-y-2'>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Implementação IAM
+                {t('footer.serviceItems.iamImplementation')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Consultoria de Segurança
+                {t('footer.serviceItems.securityConsulting')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Automação de Processos
+                {t('footer.serviceItems.processAutomation')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Suporte Técnico
+                {t('footer.serviceItems.techSupport')}
               </Link>
             </div>
           </div>
           <div className='space-y-4'>
-            <h3 className='text-lg font-semibold'>Empresa</h3>
+            <h3 className='text-lg font-semibold'>{t('footer.company')}</h3>
             <div className='space-y-2'>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Sobre Nós
+                {t('footer.companyItems.about')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Cases de Sucesso
+                {t('footer.companyItems.cases')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Blog
+                {t('footer.companyItems.blog')}
               </Link>
               <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
-                Contato
+                {t('footer.companyItems.contact')}
               </Link>
             </div>
           </div>
           <div className='space-y-4'>
-            <h3 className='text-lg font-semibold'>Contato</h3>
+            <h3 className='text-lg font-semibold'>{t('footer.contact')}</h3>
             <div className='space-y-2 text-gray-400'>
               <div>www.trustaccess.com.br</div>
               <div>contato@trustaccess.com.br</div>
@@ -80,17 +82,17 @@ export default function Footer() {
         </div>
         <div className='border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center'>
           <p className='text-gray-400 text-sm'>
-            © {new Date().getFullYear()} Trust Access. Todos os direitos reservados.
+            © {new Date().getFullYear()} Trust Access. {t('footer.rights')}
           </p>
           <div className='flex space-x-6 mt-4 md:mt-0'>
             <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
-              Política de Privacidade
+              {t('footer.privacy')}
             </Link>
             <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
-              Termos de Serviço
+              {t('footer.terms')}
             </Link>
             <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
-              LGPD
+              {t('footer.lgpd')}
             </Link>
           </div>
         </div>

--- a/components/organisms/services-section.tsx
+++ b/components/organisms/services-section.tsx
@@ -8,24 +8,26 @@ import {
   SelectValue,
 } from '@/components/atoms/ui/select';
 import { Users, Shield, Lock } from 'lucide-react';
+import { useI18n } from '@/lib/i18n';
 
 export default function ServicesSection() {
+  const { t } = useI18n();
   return (
     <section id='services' className='py-20 md:py-32'>
       <div className='container px-4 md:px-6'>
         <div className='text-center space-y-4 mb-16'>
           <h2 className='text-3xl font-bold tracking-tight sm:text-4xl md:text-5xl text-blue-600'>
-            Com a Trust Access, você pode:
+            {t('services.intro')}
           </h2>
         </div>
         <div className='grid gap-16 lg:grid-cols-2 items-center'>
           <div className='space-y-8'>
             <div className='space-y-6'>
               <h3 className='text-3xl font-bold text-gray-900'>
-                Proteger Dados Sensíveis Sem Limitar Sua Capacidade de Compartilhá-los
+                {t('services.title')}
               </h3>
               <p className='text-lg text-gray-600 leading-relaxed'>
-                A Trust Access facilita a adição de proteção a e-mails, arquivos, anexos e até mesmo dados fluindo através de outros aplicativos SaaS – sem necessidade de novas contas. Essa proteção se estende além do perímetro da sua organização para dar controle auditável mesmo depois que os dados saíram da sua rede.
+                {t('services.description')}
               </p>
             </div>
           </div>
@@ -38,7 +40,7 @@ export default function ServicesSection() {
                     <Users className='w-4 h-4 text-white' />
                   </div>
                   <div className='flex-1'>
-                    <div className='text-sm text-gray-500'>Para</div>
+                    <div className='text-sm text-gray-500'>{t('common.to')}</div>
                     <div className='font-medium'>admin@empresa.com.br</div>
                   </div>
                   <Button size='sm' variant='ghost'>
@@ -50,7 +52,7 @@ export default function ServicesSection() {
                     <Users className='w-4 h-4 text-white' />
                   </div>
                   <div className='flex-1'>
-                    <div className='text-sm text-gray-500'>De</div>
+                    <div className='text-sm text-gray-500'>{t('common.from')}</div>
                     <div className='font-medium'>contato@trustaccess.com.br</div>
                   </div>
                   <Button size='sm' variant='ghost'>
@@ -59,26 +61,26 @@ export default function ServicesSection() {
                 </div>
                 <div className='bg-blue-50 rounded-lg p-4 space-y-3'>
                   <div className='flex items-center justify-between'>
-                    <span className='text-sm font-medium text-blue-700'>OPÇÕES DE MENSAGEM</span>
+                    <span className='text-sm font-medium text-blue-700'>{t('services.messageOptions')}</span>
                     <div className='flex items-center space-x-2'>
-                      <span className='text-xs text-blue-600'>Proteção</span>
+                      <span className='text-xs text-blue-600'>{t('common.protection')}</span>
                       <div className='w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
-                      <span className='text-xs font-medium text-blue-600'>ON</span>
+                      <span className='text-xs font-medium text-blue-600'>{t('common.on')}</span>
                     </div>
                   </div>
                   <div className='space-y-2'>
                     <div className='flex items-center space-x-2'>
                       <Shield className='w-4 h-4 text-blue-500' />
-                      <span className='text-sm'>Desabilitar Encaminhamento</span>
+                      <span className='text-sm'>{t('services.disableForwarding')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Users className='w-4 h-4 text-blue-500' />
-                      <span className='text-sm'>Data de Expiração</span>
+                      <span className='text-sm'>{t('services.expirationDate')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
@@ -88,27 +90,27 @@ export default function ServicesSection() {
                     <Input placeholder='1' className='w-16 h-8' />
                     <Select>
                       <SelectTrigger className='w-24 h-8'>
-                        <SelectValue placeholder='Semana' />
+                        <SelectValue placeholder={t('common.week')} />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value='week'>Semana</SelectItem>
-                        <SelectItem value='month'>Mês</SelectItem>
+                        <SelectItem value='week'>{t('common.week')}</SelectItem>
+                        <SelectItem value='month'>{t('common.month')}</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>
                   <div className='text-xs text-gray-500'>14/7/2024 @ 10:04 AM</div>
                   <div className='border-t pt-3 space-y-2'>
-                    <div className='text-sm font-medium text-blue-700'>OPÇÕES DE ANEXO</div>
+                    <div className='text-sm font-medium text-blue-700'>{t('services.attachmentOptions')}</div>
                     <div className='flex items-center space-x-2'>
                       <Lock className='w-4 h-4 text-blue-500' />
-                      <span className='text-sm'>Marca d&apos;água</span>
+                      <span className='text-sm'>{t('common.watermark')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Shield className='w-4 h-4 text-blue-500' />
-                      <span className='text-sm'>Proteção Persistente</span>
+                      <span className='text-sm'>{t('services.persistentProtection')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
                         <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
                       </div>

--- a/components/organisms/services-section.tsx
+++ b/components/organisms/services-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { Button } from '@/components/atoms/ui/button';
 import { Input } from '@/components/atoms/ui/input';
 import {

--- a/components/organisms/trust-section.tsx
+++ b/components/organisms/trust-section.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useI18n } from '@/lib/i18n';
 
 export default function TrustSection() {

--- a/components/organisms/trust-section.tsx
+++ b/components/organisms/trust-section.tsx
@@ -1,14 +1,17 @@
+import { useI18n } from '@/lib/i18n';
+
 export default function TrustSection() {
+  const { t } = useI18n();
   return (
     <section className='py-16 bg-gradient-to-r from-teal-50 to-blue-50'>
       <div className='container px-4 md:px-6'>
         <div className='text-center space-y-8'>
           <p className='text-lg font-medium text-gray-700 uppercase tracking-wide'>
-            Mais de{' '}
+            {t('trust.before')}{' '}
             <span className='font-bold text-2xl bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent'>
-              500+ EMPRESAS
+              {t('trust.highlight')}
             </span>{' '}
-            confiam na Trust Access para segurança e gestão de acesso.
+            {t('trust.after')}
           </p>
           <div className='grid grid-cols-2 md:grid-cols-4 gap-8 items-center opacity-60'>
             <div className='flex items-center justify-center'>

--- a/lib/i18n/en.json
+++ b/lib/i18n/en.json
@@ -16,5 +16,80 @@
     "description1": "We empower companies with complete IAM and CIAM solutions, combining authentication, governance and application and API security. We ensure efficient access control with focus on protection and a great user experience.",
     "description2": "We offer integrations, onboarding/offboarding automation, technical support and training. Safer, more agile operations aligned with today's digital security requirements.",
     "cta": "Schedule Demo"
+  },
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "common": {
+    "to": "To",
+    "from": "From",
+    "protection": "Protection",
+    "on": "On",
+    "watermark": "Watermark",
+    "week": "Week",
+    "month": "Month"
+  },
+  "audit": {
+    "title": "Audit and Control Data Flow Inside and Outside Your Organization",
+    "description": "Protect data in motion, whether an incoming email or an outgoing message, or an internal system page. With Trust Access, you can change or revoke access permissions at any time.",
+    "imageAlt": "Data audit and control",
+    "emailAlt": "Email content preview"
+  },
+  "compliance": {
+    "imageAlt": "Professional working on compliance",
+    "reportTitle": "Quarterly Report",
+    "open": "Opened",
+    "openedByMe": "5:05 PM by me",
+    "created": "Created",
+    "createdWith": "5:05 PM with Trust Access for Drive",
+    "disableResharing": "Disable re-sharing",
+    "expirationNote": "Expiration date (click to reset)",
+    "revokeAccess": "Revoke Access for all Guests",
+    "allowedUsers": "Allowed Users (3)",
+    "accessed": "Accessed 12 minutes ago",
+    "title": "Strengthen Compliance",
+    "description": "Whether in finance, manufacturing, education or health, Trust Access encryption and access controls support even the most rigorous regulations, including LGPD, GDPR, ISO 27001, SOC 2, and many others."
+  },
+  "services": {
+    "intro": "With Trust Access, you can:",
+    "title": "Protect Sensitive Data Without Limiting Your Ability to Share It",
+    "description": "Trust Access makes it easy to add protection to emails, files, attachments and even data flowing through other SaaS applications—no new accounts needed. This protection extends beyond your organization’s perimeter to provide auditable control even after data leaves your network.",
+    "messageOptions": "MESSAGE OPTIONS",
+    "disableForwarding": "Disable Forwarding",
+    "expirationDate": "Expiration Date",
+    "attachmentOptions": "ATTACHMENT OPTIONS",
+    "persistentProtection": "Persistent Protection"
+  },
+  "trust": {
+    "before": "More than",
+    "highlight": "500+ COMPANIES",
+    "after": "trust Trust Access for security and access management."
+  },
+  "clients": {
+    "heading": "Real clients. Real successes. Proven."
+  },
+  "footer": {
+    "tagline": "Experts in IAM and digital security. We implement robust identity and access management solutions.",
+    "services": "Services",
+    "serviceItems": {
+      "iamImplementation": "IAM Implementation",
+      "securityConsulting": "Security Consulting",
+      "processAutomation": "Process Automation",
+      "techSupport": "Technical Support"
+    },
+    "company": "Company",
+    "companyItems": {
+      "about": "About Us",
+      "cases": "Success Stories",
+      "blog": "Blog",
+      "contact": "Contact"
+    },
+    "contact": "Contact",
+    "rights": "All rights reserved.",
+    "privacy": "Privacy Policy",
+    "terms": "Terms of Service",
+    "lgpd": "LGPD"
   }
 }

--- a/lib/i18n/es.json
+++ b/lib/i18n/es.json
@@ -16,5 +16,80 @@
     "description1": "Capacitamos empresas con soluciones completas de IAM y CIAM, uniendo autenticación, gobernanza y seguridad de aplicaciones y API. Garantizamos control de acceso eficiente, enfocado en protección y una buena experiencia de usuario.",
     "description2": "Ofrecemos integraciones, automatización de onboarding/offboarding, soporte técnico y capacitaciones. Operaciones más seguras, ágiles y alineadas con las exigencias actuales de seguridad digital.",
     "cta": "Programar Demo"
+  },
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "pt": "Portugués"
+  },
+  "common": {
+    "to": "Para",
+    "from": "De",
+    "protection": "Protección",
+    "on": "On",
+    "watermark": "Marca de agua",
+    "week": "Semana",
+    "month": "Mes"
+  },
+  "audit": {
+    "title": "Auditar y Controlar el Flujo de Datos Dentro y Fuera de su Organización",
+    "description": "Proteja los datos en movimiento, ya sea un correo entrante o un mensaje saliente, o una página de sistema interno. Con Trust Access, puede cambiar o revocar los permisos de acceso en cualquier momento.",
+    "imageAlt": "Auditoría y control de datos",
+    "emailAlt": "Vista previa del contenido del correo"
+  },
+  "compliance": {
+    "imageAlt": "Profesional trabajando en cumplimiento",
+    "reportTitle": "Informe Trimestral",
+    "open": "Abierto",
+    "openedByMe": "5:05 PM por mí",
+    "created": "Creado",
+    "createdWith": "5:05 PM con Trust Access para Drive",
+    "disableResharing": "Deshabilitar re-compartir",
+    "expirationNote": "Fecha de expiración (clic para restablecer)",
+    "revokeAccess": "Revocar Acceso de todos los Invitados",
+    "allowedUsers": "Usuarios Permitidos (3)",
+    "accessed": "Accedido hace 12 minutos",
+    "title": "Fortalecer Cumplimiento",
+    "description": "Ya sea en finanzas, manufactura, educación o salud, la encriptación y los controles de acceso de Trust Access respaldan incluso las regulaciones más rigurosas, incluyendo LGPD, GDPR, ISO 27001, SOC 2 y muchas otras."
+  },
+  "services": {
+    "intro": "Con Trust Access, puedes:",
+    "title": "Proteger Datos Sensibles Sin Limitar Tu Capacidad de Compartirlos",
+    "description": "Trust Access facilita añadir protección a correos electrónicos, archivos, adjuntos e incluso a los datos que fluyen a través de otras aplicaciones SaaS, sin necesidad de nuevas cuentas. Esta protección se extiende más allá del perímetro de tu organización para brindar control auditado incluso después de que los datos salen de tu red.",
+    "messageOptions": "OPCIONES DE MENSAJE",
+    "disableForwarding": "Deshabilitar Reenvío",
+    "expirationDate": "Fecha de Expiración",
+    "attachmentOptions": "OPCIONES DE ADJUNTO",
+    "persistentProtection": "Protección Persistente"
+  },
+  "trust": {
+    "before": "Más de",
+    "highlight": "500+ EMPRESAS",
+    "after": "confían en Trust Access para seguridad y gestión de acceso."
+  },
+  "clients": {
+    "heading": "Clientes reales. Éxitos reales. Comprobados."
+  },
+  "footer": {
+    "tagline": "Especialistas en IAM y seguridad digital. Implementamos soluciones robustas de gestión de identidades y accesos.",
+    "services": "Servicios",
+    "serviceItems": {
+      "iamImplementation": "Implementación IAM",
+      "securityConsulting": "Consultoría de Seguridad",
+      "processAutomation": "Automatización de Procesos",
+      "techSupport": "Soporte Técnico"
+    },
+    "company": "Empresa",
+    "companyItems": {
+      "about": "Sobre Nosotros",
+      "cases": "Casos de Éxito",
+      "blog": "Blog",
+      "contact": "Contacto"
+    },
+    "contact": "Contacto",
+    "rights": "Todos los derechos reservados.",
+    "privacy": "Política de Privacidad",
+    "terms": "Términos de Servicio",
+    "lgpd": "LGPD"
   }
 }

--- a/lib/i18n/pt.json
+++ b/lib/i18n/pt.json
@@ -16,5 +16,80 @@
     "description1": "Capacitamos empresas com soluções completas de IAM e CIAM, unindo autenticação, governança e segurança de aplicações e APIs. Garantimos controle de acesso eficiente, com foco em proteção e boa experiência do usuário.",
     "description2": "Oferecemos integrações, automação de onboarding/offboarding, suporte técnico e treinamentos. Operações mais seguras, ágeis e alinhadas com as exigências atuais de segurança digital.",
     "cta": "Agendar Demo"
+  },
+  "languages": {
+    "en": "English",
+    "es": "Español",
+    "pt": "Português"
+  },
+  "common": {
+    "to": "Para",
+    "from": "De",
+    "protection": "Proteção",
+    "on": "On",
+    "watermark": "Marca d'água",
+    "week": "Semana",
+    "month": "Mês"
+  },
+  "audit": {
+    "title": "Auditar e Controlar o Fluxo de Dados Dentro e Fora da Sua Organização",
+    "description": "Proteja dados em movimento, seja um e-mail de entrada ou uma mensagem de saída, ou uma página de sistema interno. Com a Trust Access, você pode alterar ou revogar permissões de acesso a qualquer momento.",
+    "imageAlt": "Auditoria e controle de dados",
+    "emailAlt": "Pré-visualização do conteúdo do e-mail"
+  },
+  "compliance": {
+    "imageAlt": "Profissional trabalhando em conformidade",
+    "reportTitle": "Relatório Trimestral",
+    "open": "Aberto",
+    "openedByMe": "5:05 PM por mim",
+    "created": "Criado",
+    "createdWith": "5:05 PM com Trust Access para Drive",
+    "disableResharing": "Desabilitar re-compartilhamento",
+    "expirationNote": "Data de expiração (clique para redefinir)",
+    "revokeAccess": "Revogar Acesso de todos os Convidados",
+    "allowedUsers": "Usuários Permitidos (3)",
+    "accessed": "Acessado 12 minutos atrás",
+    "title": "Fortalecer Conformidade",
+    "description": "Seja você do setor financeiro, manufatura, educação ou saúde, a criptografia e controles de acesso da Trust Access suportam até mesmo as regulamentações mais rigorosas, incluindo LGPD, GDPR, ISO 27001, SOC 2, e muitas outras."
+  },
+  "services": {
+    "intro": "Com a Trust Access, você pode:",
+    "title": "Proteger Dados Sensíveis Sem Limitar Sua Capacidade de Compartilhá-los",
+    "description": "A Trust Access facilita a adição de proteção a e-mails, arquivos, anexos e até mesmo dados fluindo através de outros aplicativos SaaS – sem necessidade de novas contas. Essa proteção se estende além do perímetro da sua organização para dar controle auditável mesmo depois que os dados saíram da sua rede.",
+    "messageOptions": "OPÇÕES DE MENSAGEM",
+    "disableForwarding": "Desabilitar Encaminhamento",
+    "expirationDate": "Data de Expiração",
+    "attachmentOptions": "OPÇÕES DE ANEXO",
+    "persistentProtection": "Proteção Persistente"
+  },
+  "trust": {
+    "before": "Mais de",
+    "highlight": "500+ EMPRESAS",
+    "after": "confiam na Trust Access para segurança e gestão de acesso."
+  },
+  "clients": {
+    "heading": "Clientes reais. Sucessos reais. Comprovados."
+  },
+  "footer": {
+    "tagline": "Especialistas em IAM e segurança digital. Implementamos soluções robustas de gestão de identidades e acessos.",
+    "services": "Serviços",
+    "serviceItems": {
+      "iamImplementation": "Implementação IAM",
+      "securityConsulting": "Consultoria de Segurança",
+      "processAutomation": "Automação de Processos",
+      "techSupport": "Suporte Técnico"
+    },
+    "company": "Empresa",
+    "companyItems": {
+      "about": "Sobre Nós",
+      "cases": "Cases de Sucesso",
+      "blog": "Blog",
+      "contact": "Contato"
+    },
+    "contact": "Contato",
+    "rights": "Todos os direitos reservados.",
+    "privacy": "Política de Privacidade",
+    "terms": "Termos de Serviço",
+    "lgpd": "LGPD"
   }
 }


### PR DESCRIPTION
## Summary
- move UI strings from components into `lib/i18n` dictionaries
- use `t()` lookups throughout sections and language switcher
- provide English, Spanish, and Portuguese translations for new keys

## Testing
- `pnpm lint`
- `pnpm exec vitest run`

------
https://chatgpt.com/codex/tasks/task_e_68974b97225883309ea4a00f30b34308