### PR TITLE
feat: enhance language switcher with select and persistence

### DIFF
--- a/__tests__/language-switcher.test.tsx
+++ b/__tests__/language-switcher.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LanguageSwitcher from "@/components/atoms/language-switcher";
+import { I18nProvider } from "@/lib/i18n";
+
+describe("LanguageSwitcher", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("allows keyboard navigation to change language", async () => {
+    const user = userEvent.setup();
+    render(
+      <I18nProvider>
+        <LanguageSwitcher />
+      </I18nProvider>,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    await screen.findByText("Português");
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    await user.keyboard("{ArrowUp}{ArrowUp}{Enter}");
+    await screen.findByText("English");
+    expect(trigger).toHaveTextContent("English");
+    expect(localStorage.getItem("locale")).toBe("en");
+  });
+
+  it("renders options with accessible labels", async () => {
+    const user = userEvent.setup();
+    render(
+      <I18nProvider>
+        <LanguageSwitcher />
+      </I18nProvider>,
+    );
+
+    const trigger = screen.getByRole("combobox");
+    await user.click(trigger);
+    expect(
+      await screen.findByRole("option", { name: "English" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Español" }),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByRole("option", { name: "Português" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/components/atoms/language-switcher.tsx
+++ b/components/atoms/language-switcher.tsx
@@ -1,18 +1,41 @@
-'use client';
+"use client";
 
-import { Locale, useI18n } from '@/lib/i18n';
+import { Locale, useI18n } from "@/lib/i18n";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/atoms/ui/select";
 
 export default function LanguageSwitcher() {
   const { t, locale, setLocale } = useI18n();
+  const languages: { value: Locale; label: string; flag: string }[] = [
+    { value: "en", label: t("languages.en"), flag: "🇺🇸" },
+    { value: "es", label: t("languages.es"), flag: "🇪🇸" },
+    { value: "pt", label: t("languages.pt"), flag: "🇧🇷" },
+  ];
+
   return (
-    <select
-      className='border rounded px-2 py-1 text-sm'
-      value={locale}
-      onChange={(e) => setLocale(e.target.value as Locale)}
-    >
-      <option value='en'>{t('languages.en')}</option>
-      <option value='es'>{t('languages.es')}</option>
-      <option value='pt'>{t('languages.pt')}</option>
-    </select>
+    <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
+      <SelectTrigger className="w-[120px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {languages.map((lang) => (
+          <SelectItem
+            key={lang.value}
+            value={lang.value}
+            aria-label={lang.label}
+          >
+            <span className="flex items-center gap-2">
+              <span aria-hidden="true">{lang.flag}</span>
+              {lang.label}
+            </span>
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
   );
 }

--- a/lib/i18n/index.tsx
+++ b/lib/i18n/index.tsx
@@ -1,8 +1,8 @@
-'use client';
+"use client";
 
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState } from "react";
 
-export type Locale = 'en' | 'es' | 'pt';
+export type Locale = "en" | "es" | "pt";
 
 interface I18nContextProps {
   t: (key: string) => string;
@@ -12,33 +12,49 @@ interface I18nContextProps {
 
 const I18nContext = createContext<I18nContextProps>({
   t: (key: string) => key,
-  locale: 'pt',
+  locale: "pt",
   setLocale: () => {},
 });
 
-function getValue(dict: Record<string, unknown>, key: string): string | undefined {
+function getValue(
+  dict: Record<string, unknown>,
+  key: string,
+): string | undefined {
   return key
-    .split('.')
+    .split(".")
     .reduce(
       (acc: unknown, part) =>
-        acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[part] : undefined,
+        acc && typeof acc === "object"
+          ? (acc as Record<string, unknown>)[part]
+          : undefined,
       dict,
     ) as string | undefined;
 }
 
-const loaders: Record<Locale, () => Promise<{ default: Record<string, unknown> }>> = {
-  en: () => import('./en.json'),
-  es: () => import('./es.json'),
-  pt: () => import('./pt.json'),
+const loaders: Record<
+  Locale,
+  () => Promise<{ default: Record<string, unknown> }>
+> = {
+  en: () => import("./en.json"),
+  es: () => import("./es.json"),
+  pt: () => import("./pt.json"),
 };
 
 export function I18nProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocale] = useState<Locale>('pt');
+  const [locale, setLocale] = useState<Locale>("pt");
   const [dictionary, setDictionary] = useState<Record<string, unknown>>({});
+
+  useEffect(() => {
+    const storedLocale = localStorage.getItem("locale") as Locale | null;
+    if (storedLocale) {
+      setLocale(storedLocale);
+    }
+  }, []);
 
   useEffect(() => {
     loaders[locale]().then((module) => setDictionary(module.default));
     document.documentElement.lang = locale;
+    localStorage.setItem("locale", locale);
   }, [locale]);
 
   function t(key: string) {

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.6.4",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,10 +170,10 @@ importers:
         version: 9.1.1(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))
       '@storybook/addon-styling':
         specifier: ^1.3.7
-        version: 1.3.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(less@4.4.0)(postcss@8.5.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))
+        version: 1.3.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(less@4.4.0)(postcss@8.5.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))
       '@storybook/nextjs':
         specifier: ^9.1.1
-        version: 9.1.1(esbuild@0.18.20)(next@15.2.4(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.18.20))
+        version: 9.1.1(esbuild@0.25.8)(next@15.2.4(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.25.8))
       '@storybook/react':
         specifier: ^9.1.1
         version: 9.1.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
@@ -186,6 +186,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.0
         version: 16.3.0(@testing-library/dom@10.4.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22
         version: 22.17.1
@@ -7760,7 +7763,7 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
-  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.18.20))':
+  '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.25.8))':
     dependencies:
       ansi-html: 0.0.9
       core-js-pure: 3.45.0
@@ -7770,7 +7773,7 @@ snapshots:
       react-refresh: 0.14.2
       schema-utils: 4.3.2
       source-map: 0.7.6
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     optionalDependencies:
       type-fest: 2.19.0
       webpack-hot-middleware: 2.26.1
@@ -8967,7 +8970,7 @@ snapshots:
       storybook: 9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
 
-  '@storybook/addon-styling@1.3.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(less@4.4.0)(postcss@8.5.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))':
+  '@storybook/addon-styling@1.3.7(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(less@4.4.0)(postcss@8.5.6)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))':
     dependencies:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.2
@@ -8980,19 +8983,19 @@ snapshots:
       '@storybook/preview-api': 7.6.20
       '@storybook/theming': 7.6.20(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@storybook/types': 7.6.20
-      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.18.20))
-      less-loader: 11.1.4(less@4.4.0)(webpack@5.101.0(esbuild@0.18.20))
-      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.25.8))
+      less-loader: 11.1.4(less@4.4.0)(webpack@5.101.0(esbuild@0.25.8))
+      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))
       prettier: 2.8.8
       resolve-url-loader: 5.0.0
-      sass-loader: 13.3.3(webpack@5.101.0(esbuild@0.18.20))
-      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.18.20))
+      sass-loader: 13.3.3(webpack@5.101.0(esbuild@0.25.8))
+      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.25.8))
     optionalDependencies:
       less: 4.4.0
       postcss: 8.5.6
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@types/react'
@@ -9031,22 +9034,22 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/builder-webpack5@9.1.1(esbuild@0.18.20)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)':
+  '@storybook/builder-webpack5@9.1.1(esbuild@0.25.8)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/core-webpack': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.18.20))
+      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.25.8))
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))
-      html-webpack-plugin: 5.6.3(webpack@5.101.0(esbuild@0.18.20))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))
+      html-webpack-plugin: 5.6.3(webpack@5.101.0(esbuild@0.25.8))
       magic-string: 0.30.17
       storybook: 9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1))
-      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.18.20))
-      terser-webpack-plugin: 5.3.14(esbuild@0.18.20)(webpack@5.101.0(esbuild@0.18.20))
+      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.25.8))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.0(esbuild@0.25.8))
       ts-dedent: 2.2.0
-      webpack: 5.101.0(esbuild@0.18.20)
-      webpack-dev-middleware: 6.1.3(webpack@5.101.0(esbuild@0.18.20))
+      webpack: 5.101.0(esbuild@0.25.8)
+      webpack-dev-middleware: 6.1.3(webpack@5.101.0(esbuild@0.25.8))
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -9206,7 +9209,7 @@ snapshots:
       - react
       - react-dom
 
-  '@storybook/nextjs@9.1.1(esbuild@0.18.20)(next@15.2.4(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.18.20))':
+  '@storybook/nextjs@9.1.1(esbuild@0.25.8)(next@15.2.4(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(type-fest@2.19.0)(typescript@5.9.2)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.25.8))':
     dependencies:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.28.0)
@@ -9221,33 +9224,33 @@ snapshots:
       '@babel/preset-react': 7.27.1(@babel/core@7.28.0)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.0)
       '@babel/runtime': 7.28.2
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.18.20))
-      '@storybook/builder-webpack5': 9.1.1(esbuild@0.18.20)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
-      '@storybook/preset-react-webpack': 9.1.1(esbuild@0.18.20)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.2)(type-fest@2.19.0)(webpack-hot-middleware@2.26.1)(webpack@5.101.0(esbuild@0.25.8))
+      '@storybook/builder-webpack5': 9.1.1(esbuild@0.25.8)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
+      '@storybook/preset-react-webpack': 9.1.1(esbuild@0.25.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
       '@storybook/react': 9.1.1(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)
       '@types/semver': 7.7.0
-      babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.18.20))
-      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.18.20))
+      babel-loader: 9.2.1(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.25.8))
+      css-loader: 6.11.0(webpack@5.101.0(esbuild@0.25.8))
       image-size: 2.0.2
       loader-utils: 3.3.1
       next: 15.2.4(@babel/core@7.28.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      node-polyfill-webpack-plugin: 2.0.1(webpack@5.101.0(esbuild@0.18.20))
+      node-polyfill-webpack-plugin: 2.0.1(webpack@5.101.0(esbuild@0.25.8))
       postcss: 8.5.6
-      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))
+      postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-refresh: 0.14.2
       resolve-url-loader: 5.0.0
-      sass-loader: 16.0.5(webpack@5.101.0(esbuild@0.18.20))
+      sass-loader: 16.0.5(webpack@5.101.0(esbuild@0.25.8))
       semver: 7.7.2
       storybook: 9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1))
-      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.18.20))
+      style-loader: 3.3.4(webpack@5.101.0(esbuild@0.25.8))
       styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.1.1)
       tsconfig-paths: 4.2.0
       tsconfig-paths-webpack-plugin: 4.2.0
     optionalDependencies:
       typescript: 5.9.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - '@rspack/core'
       - '@swc/core'
@@ -9268,10 +9271,10 @@ snapshots:
 
   '@storybook/node-logger@7.6.20': {}
 
-  '@storybook/preset-react-webpack@9.1.1(esbuild@0.18.20)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)':
+  '@storybook/preset-react-webpack@9.1.1(esbuild@0.25.8)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/core-webpack': 9.1.1(storybook@9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1)))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))
       '@types/semver': 7.7.0
       find-up: 7.0.0
       magic-string: 0.30.17
@@ -9282,7 +9285,7 @@ snapshots:
       semver: 7.7.2
       storybook: 9.1.1(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.1(@types/node@22.17.1)(jiti@1.21.7)(less@4.4.0)(terser@5.43.1)(yaml@2.8.1))
       tsconfig-paths: 4.2.0
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -9309,7 +9312,7 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8))':
     dependencies:
       debug: 4.4.1
       endent: 2.1.0
@@ -9319,7 +9322,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.2)
       tslib: 2.8.1
       typescript: 5.9.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - supports-color
 
@@ -10134,12 +10137,12 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.18.20)):
+  babel-loader@9.2.1(@babel/core@7.28.0)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@babel/core': 7.28.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   babel-plugin-polyfill-corejs2@0.4.14(@babel/core@7.28.0):
     dependencies:
@@ -10494,7 +10497,7 @@ snapshots:
       randombytes: 2.1.0
       randomfill: 1.0.4
 
-  css-loader@6.11.0(webpack@5.101.0(esbuild@0.18.20)):
+  css-loader@6.11.0(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.6)
       postcss: 8.5.6
@@ -10505,7 +10508,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   css-select@4.3.0:
     dependencies:
@@ -10952,8 +10955,8 @@ snapshots:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -10976,7 +10979,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -10987,22 +10990,22 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.39.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11013,7 +11016,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.39.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11272,7 +11275,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chalk: 4.1.2
@@ -11287,7 +11290,7 @@ snapshots:
       semver: 7.7.2
       tapable: 2.2.2
       typescript: 5.9.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   form-data@4.0.4:
     dependencies:
@@ -11481,7 +11484,7 @@ snapshots:
       relateurl: 0.2.7
       terser: 5.43.1
 
-  html-webpack-plugin@5.6.3(webpack@5.101.0(esbuild@0.18.20)):
+  html-webpack-plugin@5.6.3(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -11489,7 +11492,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.2
     optionalDependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -11819,10 +11822,10 @@ snapshots:
       dotenv: 16.6.1
       dotenv-expand: 10.0.0
 
-  less-loader@11.1.4(less@4.4.0)(webpack@5.101.0(esbuild@0.18.20)):
+  less-loader@11.1.4(less@4.4.0)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       less: 4.4.0
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   less@4.4.0:
     dependencies:
@@ -12033,7 +12036,7 @@ snapshots:
     dependencies:
       whatwg-url: 5.0.0
 
-  node-polyfill-webpack-plugin@2.0.1(webpack@5.101.0(esbuild@0.18.20)):
+  node-polyfill-webpack-plugin@2.0.1(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       assert: 2.1.0
       browserify-zlib: 0.2.0
@@ -12060,7 +12063,7 @@ snapshots:
       url: 0.11.4
       util: 0.12.5
       vm-browserify: 1.1.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   node-releases@2.0.19: {}
 
@@ -12300,24 +12303,24 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
 
-  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20)):
+  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.18.20)):
+  postcss-loader@8.1.1(postcss@8.5.6)(typescript@5.9.2)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@5.9.2)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     transitivePeerDependencies:
       - typescript
 
@@ -12760,16 +12763,16 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.3.3(webpack@5.101.0(esbuild@0.18.20)):
+  sass-loader@13.3.3(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       neo-async: 2.6.2
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
-  sass-loader@16.0.5(webpack@5.101.0(esbuild@0.18.20)):
+  sass-loader@16.0.5(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   sax@1.4.1:
     optional: true
@@ -13067,9 +13070,9 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  style-loader@3.3.4(webpack@5.101.0(esbuild@0.18.20)):
+  style-loader@3.3.4(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   styled-jsx@5.1.6(@babel/core@7.28.0)(react@19.1.1):
     dependencies:
@@ -13141,16 +13144,16 @@ snapshots:
     dependencies:
       memoizerific: 1.11.3
 
-  terser-webpack-plugin@5.3.14(esbuild@0.18.20)(webpack@5.101.0(esbuild@0.18.20)):
+  terser-webpack-plugin@5.3.14(esbuild@0.25.8)(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.43.1
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
     optionalDependencies:
-      esbuild: 0.18.20
+      esbuild: 0.25.8
 
   terser@5.43.1:
     dependencies:
@@ -13527,7 +13530,7 @@ snapshots:
 
   webidl-conversions@7.0.0: {}
 
-  webpack-dev-middleware@6.1.3(webpack@5.101.0(esbuild@0.18.20)):
+  webpack-dev-middleware@6.1.3(webpack@5.101.0(esbuild@0.25.8)):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3
@@ -13535,7 +13538,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.101.0(esbuild@0.18.20)
+      webpack: 5.101.0(esbuild@0.25.8)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -13547,7 +13550,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.101.0(esbuild@0.18.20):
+  webpack@5.101.0(esbuild@0.25.8):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -13571,7 +13574,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(esbuild@0.18.20)(webpack@5.101.0(esbuild@0.18.20))
+      terser-webpack-plugin: 5.3.14(esbuild@0.25.8)(webpack@5.101.0(esbuild@0.25.8))
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     transitivePeerDependencies:

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,7 @@
-import '@testing-library/jest-dom';
+import "@testing-library/jest-dom";
+
+// Polyfills for Radix UI components in JSDOM
+window.HTMLElement.prototype.scrollIntoView = function () {};
+window.HTMLElement.prototype.hasPointerCapture = function () {
+  return false;
+};


### PR DESCRIPTION
## Summary
- replace HTML select with shadcn Select component with flag icons and accessible labels
- persist chosen locale in localStorage and load on mount
- add tests for keyboard navigation and accessibility of locale options

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689752bcb3688330a078c4effe9ea667