### PR TITLE
Add responsive mobile menu with adaptable language switcher

### DIFF
--- a/components/atoms/language-switcher.tsx
+++ b/components/atoms/language-switcher.tsx
@@ -8,8 +8,15 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/atoms/ui/select";
+import { cn } from "@/lib/utils";
 
-export default function LanguageSwitcher() {
+interface LanguageSwitcherProps {
+  className?: string;
+}
+
+export default function LanguageSwitcher({
+  className,
+}: LanguageSwitcherProps) {
   const { t, locale, setLocale } = useI18n();
   const languages: { value: Locale; label: string; flag: string }[] = [
     { value: "en", label: t("languages.en"), flag: "🇺🇸" },
@@ -19,7 +26,7 @@ export default function LanguageSwitcher() {
 
   return (
     <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
-      <SelectTrigger className="w-[120px]">
+      <SelectTrigger className={cn("w-full md:w-[120px]", className)}>
         <SelectValue />
       </SelectTrigger>
       <SelectContent>

--- a/components/organisms/header.tsx
+++ b/components/organisms/header.tsx
@@ -1,6 +1,12 @@
 "use client";
 
 import { Button } from '@/components/atoms/ui/button';
+import {
+  Sheet,
+  SheetContent,
+  SheetTrigger,
+  SheetClose,
+} from '@/components/atoms/ui/sheet';
 import { Menu } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -38,16 +44,45 @@ export default function Header() {
           ))}
         </nav>
         <div className='flex items-center space-x-4'>
-          <LanguageSwitcher />
-          <Button variant='ghost' className='hidden md:inline-flex'>
-            {t('header.login')}
-          </Button>
-          <Button className='bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700'>
-            {t('header.bookDemo')}
-          </Button>
-          <Button variant='ghost' size='icon' className='md:hidden'>
-            <Menu className='h-5 w-5' />
-          </Button>
+          <div className='hidden md:flex items-center space-x-4'>
+            <LanguageSwitcher />
+            <Button variant='ghost'>{t('header.login')}</Button>
+            <Button className='bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700'>
+              {t('header.bookDemo')}
+            </Button>
+          </div>
+          <Sheet>
+            <SheetTrigger asChild>
+              <Button variant='ghost' size='icon' className='md:hidden'>
+                <Menu className='h-5 w-5' />
+              </Button>
+            </SheetTrigger>
+            <SheetContent side='right' className='flex flex-col space-y-6 p-6'>
+              <nav className='flex flex-col space-y-4'>
+                {navItems.map(({ href, label }) => (
+                  <SheetClose asChild key={href}>
+                    <Link
+                      href={href}
+                      className='text-sm font-medium text-gray-600 hover:text-gray-900 transition-colors'
+                    >
+                      {t(label)}
+                    </Link>
+                  </SheetClose>
+                ))}
+              </nav>
+              <LanguageSwitcher />
+              <SheetClose asChild>
+                <Button variant='ghost' className='w-full'>
+                  {t('header.login')}
+                </Button>
+              </SheetClose>
+              <SheetClose asChild>
+                <Button className='w-full bg-gradient-to-r from-teal-500 to-blue-600 hover:from-teal-600 hover:to-blue-700'>
+                  {t('header.bookDemo')}
+                </Button>
+              </SheetClose>
+            </SheetContent>
+          </Sheet>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- wrap navigation, language switcher and actions in a mobile sheet menu
- allow LanguageSwitcher width to adapt on small screens

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_6897553e9f3c8330b644d501ffb4df3f