### PR TITLE
Improve dark theme coverage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,7 +15,7 @@ const Footer = dynamic(() => import('@/components/organisms/footer'));
 
 export default function TrustAccessLanding() {
   return (
-    <div className='min-h-screen bg-white'>
+    <div className='min-h-screen bg-background'>
       <Suspense fallback={<Skeleton className='h-16 w-full' />}>
         <Header />
       </Suspense>

--- a/components/molecules/demo-form.tsx
+++ b/components/molecules/demo-form.tsx
@@ -51,7 +51,7 @@ export default function DemoForm() {
   };
 
   return (
-    <section id='contact' className='py-20 md:py-32 bg-white'>
+    <section id='contact' className='py-20 md:py-32 bg-background'>
       <div className='container px-4 md:px-6'>
         <div className='max-w-2xl mx-auto'>
           <Card className='border-0 shadow-xl'>
@@ -181,7 +181,7 @@ export default function DemoForm() {
                   )}
                 </div>
                 <div className='space-y-4'>
-                  <div className='text-sm text-gray-600'>
+                  <div className='text-sm text-muted-foreground'>
                     Ao completar este formulário, você concorda em receber comunicações de marketing da Trust Access. Você pode cancelar a inscrição a qualquer momento. Consulte nossa{' '}
                     <Link href='#' className='text-blue-600 hover:underline'>
                       Política de Privacidade

--- a/components/organisms/audit-section.tsx
+++ b/components/organisms/audit-section.tsx
@@ -13,16 +13,16 @@ export default function AuditSection() {
         <div className='grid gap-16 lg:grid-cols-2 items-center'>
           <div className='space-y-8'>
             <div className='space-y-6'>
-              <h3 className='text-3xl font-bold text-gray-900'>
+              <h3 className='text-3xl font-bold text-foreground'>
                 {t('audit.title')}
               </h3>
-              <p className='text-lg text-gray-600 leading-relaxed'>
+              <p className='text-lg text-muted-foreground leading-relaxed'>
                 {t('audit.description')}
               </p>
             </div>
           </div>
           <div className='relative'>
-            <div className='bg-gradient-to-br from-purple-100 via-pink-50 to-purple-100 rounded-3xl p-8 relative overflow-hidden'>
+            <div className='bg-gradient-to-br from-purple-100 via-pink-50 to-purple-100 dark:from-purple-900 dark:via-pink-900 dark:to-purple-900 rounded-3xl p-8 relative overflow-hidden'>
               <Image
                 src='/placeholder.svg?height=400&width=600'
                 alt={t('audit.imageAlt')}
@@ -34,28 +34,28 @@ export default function AuditSection() {
                 blurDataURL={BLUR_PLACEHOLDER}
               />
               {/* Mock Email Interface Overlay */}
-              <div className='absolute top-8 right-8 bg-white rounded-lg shadow-xl p-4 w-72'>
+              <div className='absolute top-8 right-8 bg-card rounded-lg shadow-xl p-4 w-72'>
                 <div className='flex items-center space-x-2 mb-4'>
                   <div className='text-sm font-medium text-blue-600'>{t('common.to')}</div>
-                  <div className='flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1'>
-                    <div className='w-6 h-6 bg-gray-400 rounded-full'></div>
+                  <div className='flex items-center space-x-2 bg-muted rounded-full px-3 py-1'>
+                    <div className='w-6 h-6 bg-muted rounded-full'></div>
                     <span className='text-sm'>admin@empresa.com.br</span>
                     <Button size='sm' variant='ghost' className='h-4 w-4 p-0'>
-                      <span className='text-gray-400'>×</span>
+                      <span className='text-muted-foreground'>×</span>
                     </Button>
                   </div>
                 </div>
                 <div className='flex items-center space-x-2 mb-6'>
-                  <div className='text-sm font-medium text-gray-600'>{t('common.from')}</div>
-                  <div className='flex items-center space-x-2 bg-gray-100 rounded-full px-3 py-1'>
+                  <div className='text-sm font-medium text-muted-foreground'>{t('common.from')}</div>
+                  <div className='flex items-center space-x-2 bg-muted rounded-full px-3 py-1'>
                     <div className='w-6 h-6 bg-green-500 rounded-full'></div>
                     <span className='text-sm'>contato@trustaccess.com.br</span>
                     <Button size='sm' variant='ghost' className='h-4 w-4 p-0'>
-                      <span className='text-gray-400'>×</span>
+                      <span className='text-muted-foreground'>×</span>
                     </Button>
                   </div>
                 </div>
-                <div className='bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-4'>
+                <div className='bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900 dark:to-purple-900 rounded-lg p-4'>
                   <Image
                     src='/placeholder.svg?height=200&width=250'
                     alt={t('audit.emailAlt')}
@@ -71,7 +71,7 @@ export default function AuditSection() {
                     <div className='flex items-center space-x-2'>
                       <span className='text-xs text-blue-600'>{t('common.on')}</span>
                       <div className='w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                   </div>

--- a/components/organisms/clients-section.tsx
+++ b/components/organisms/clients-section.tsx
@@ -8,14 +8,14 @@ import { useI18n } from '@/lib/i18n';
 export default function ClientsSection() {
   const { t } = useI18n();
   return (
-    <section className='py-20 md:py-32 bg-white'>
+    <section className='py-20 md:py-32 bg-background'>
       <div className='container max-w-screen-xl mx-auto px-4 md:px-6'>
-        <h2 className='text-3xl md:text-5xl font-bold text-center mb-16 text-gray-900'>
+        <h2 className='text-3xl md:text-5xl font-bold text-center mb-16 text-foreground'>
           {t('clients.heading')}
         </h2>
         <div className='grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6'>
           {clientCases.map(({ img, title, heading, desc }, idx) => (
-            <Card key={idx} className='overflow-hidden shadow-md border border-gray-100'>
+            <Card key={idx} className='overflow-hidden shadow-md border border-border'>
               <Image
                 src={img}
                 alt={title}
@@ -26,9 +26,9 @@ export default function ClientsSection() {
                 placeholder='blur'
               />
               <CardContent className='p-6 space-y-4'>
-                <div className='text-sm text-gray-500'>{title}</div>
-                <h3 className='font-semibold text-lg text-gray-900'>{heading}</h3>
-                <p className='text-sm text-gray-600'>{desc}</p>
+                <div className='text-sm text-muted-foreground'>{title}</div>
+                <h3 className='font-semibold text-lg text-foreground'>{heading}</h3>
+                <p className='text-sm text-muted-foreground'>{desc}</p>
                 <span className='text-blue-600 text-xl'>→</span>
               </CardContent>
             </Card>

--- a/components/organisms/compliance-section.tsx
+++ b/components/organisms/compliance-section.tsx
@@ -9,11 +9,11 @@ import { useI18n } from '@/lib/i18n';
 export default function ComplianceSection() {
   const { t } = useI18n();
   return (
-    <section className='py-20 md:py-32 bg-gray-50'>
+    <section className='py-20 md:py-32 bg-background'>
       <div className='container px-4 md:px-6'>
         <div className='grid gap-16 lg:grid-cols-2 items-center'>
           <div className='relative'>
-            <div className='bg-gradient-to-br from-teal-100 via-blue-100 to-cyan-100 rounded-3xl p-8 relative overflow-hidden'>
+            <div className='bg-gradient-to-br from-teal-100 via-blue-100 to-cyan-100 dark:from-teal-900 dark:via-blue-900 dark:to-cyan-900 rounded-3xl p-8 relative overflow-hidden'>
               <Image
                 src='/placeholder.svg?height=400&width=600'
                 alt={t('compliance.imageAlt')}
@@ -25,26 +25,26 @@ export default function ComplianceSection() {
                 blurDataURL={BLUR_PLACEHOLDER}
               />
               {/* Mock File Interface Overlay */}
-              <div className='absolute top-12 right-8 bg-white rounded-lg shadow-xl p-4 w-64'>
+              <div className='absolute top-12 right-8 bg-card rounded-lg shadow-xl p-4 w-64'>
                 <div className='flex items-center space-x-2 mb-3'>
                   <div className='w-6 h-6 bg-red-500 rounded flex items-center justify-center'>
                     <span className='text-white text-xs'>PDF</span>
                   </div>
                   <div className='flex-1'>
                     <div className='text-sm font-medium'>{t('compliance.reportTitle')}</div>
-                    <div className='text-xs text-gray-500'>Empresa.pdf.tdf</div>
+                    <div className='text-xs text-muted-foreground'>Empresa.pdf.tdf</div>
                   </div>
                   <Button size='sm' variant='ghost'>
-                    <span className='text-gray-400'>×</span>
+                    <span className='text-muted-foreground'>×</span>
                   </Button>
                 </div>
                 <div className='space-y-2 text-xs'>
                   <div className='flex justify-between'>
-                    <span className='text-gray-600'>{t('compliance.open')}</span>
+                    <span className='text-muted-foreground'>{t('compliance.open')}</span>
                     <span>{t('compliance.openedByMe')}</span>
                   </div>
                   <div className='flex justify-between'>
-                    <span className='text-gray-600'>{t('compliance.created')}</span>
+                    <span className='text-muted-foreground'>{t('compliance.created')}</span>
                     <span>{t('compliance.createdWith')}</span>
                   </div>
                 </div>
@@ -63,7 +63,7 @@ export default function ComplianceSection() {
                       <span className='text-xs'>{t('compliance.expirationNote')}</span>
                     </div>
                   </div>
-                  <div className='text-xs text-gray-500 mt-2'>16 de fevereiro, 2023 1:45 PM</div>
+                  <div className='text-xs text-muted-foreground mt-2'>16 de fevereiro, 2023 1:45 PM</div>
                   <div className='mt-3 pt-2 border-t'>
                     <div className='flex items-center space-x-1 text-red-600 text-xs'>
                       <span className='w-2 h-2 bg-red-500 rounded-full'></span>
@@ -72,11 +72,11 @@ export default function ComplianceSection() {
                     <div className='mt-2 text-xs font-medium'>{t('compliance.allowedUsers')}</div>
                     <div className='space-y-1 mt-1'>
                       <div className='flex items-center space-x-2'>
-                        <div className='w-4 h-4 bg-gray-300 rounded-full'></div>
+                        <div className='w-4 h-4 bg-muted rounded-full'></div>
                         <span className='text-xs'>admin@empresa.com.br</span>
                       </div>
                       <div className='flex items-center space-x-2'>
-                        <div className='w-4 h-4 bg-gray-300 rounded-full'></div>
+                        <div className='w-4 h-4 bg-muted rounded-full'></div>
                         <span className='text-xs'>user@empresa.com.br</span>
                       </div>
                       <div className='flex items-center space-x-2'>
@@ -92,8 +92,8 @@ export default function ComplianceSection() {
           </div>
           <div className='space-y-8'>
             <div className='space-y-6'>
-              <h3 className='text-3xl font-bold text-gray-900'>{t('compliance.title')}</h3>
-              <p className='text-lg text-gray-600 leading-relaxed'>
+              <h3 className='text-3xl font-bold text-foreground'>{t('compliance.title')}</h3>
+              <p className='text-lg text-muted-foreground leading-relaxed'>
                 {t('compliance.description')}
               </p>
             </div>

--- a/components/organisms/footer.tsx
+++ b/components/organisms/footer.tsx
@@ -25,17 +25,17 @@ export default function Footer() {
                 Trust Access
               </span>
             </div>
-            <p className='text-gray-400 max-w-xs'>
+            <p className='text-muted-foreground max-w-xs'>
               {t('footer.tagline')}
             </p>
             <div className='flex space-x-4'>
-              <Link href='#' className='text-gray-400 hover:text-white transition-colors'>
-                <Linkedin className='h-5 w-5' />
+              <Link href='#' className='text-muted-foreground hover:text-white transition-colors'>
+              <Linkedin className='h-5 w-5' />
               </Link>
-              <Link href='#' className='text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='text-muted-foreground hover:text-white transition-colors'>
                 <Mail className='h-5 w-5' />
               </Link>
-              <Link href='#' className='text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='text-muted-foreground hover:text-white transition-colors'>
                 <Globe className='h-5 w-5' />
               </Link>
             </div>
@@ -43,16 +43,16 @@ export default function Footer() {
           <div className='space-y-4'>
             <h3 className='text-lg font-semibold'>{t('footer.services')}</h3>
             <div className='space-y-2'>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.serviceItems.iamImplementation')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.serviceItems.securityConsulting')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.serviceItems.processAutomation')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.serviceItems.techSupport')}
               </Link>
             </div>
@@ -60,40 +60,40 @@ export default function Footer() {
           <div className='space-y-4'>
             <h3 className='text-lg font-semibold'>{t('footer.company')}</h3>
             <div className='space-y-2'>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.companyItems.about')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.companyItems.cases')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.companyItems.blog')}
               </Link>
-              <Link href='#' className='block text-gray-400 hover:text-white transition-colors'>
+              <Link href='#' className='block text-muted-foreground hover:text-white transition-colors'>
                 {t('footer.companyItems.contact')}
               </Link>
             </div>
           </div>
           <div className='space-y-4'>
             <h3 className='text-lg font-semibold'>{t('footer.contact')}</h3>
-            <div className='space-y-2 text-gray-400'>
+            <div className='space-y-2 text-muted-foreground'>
               <div>www.trustaccess.com.br</div>
               <div>contato@trustaccess.com.br</div>
             </div>
           </div>
         </div>
-        <div className='border-t border-gray-800 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center'>
-          <p className='text-gray-400 text-sm'>
+        <div className='border-t border-border mt-12 pt-8 flex flex-col md:flex-row justify-between items-center'>
+          <p className='text-muted-foreground text-sm'>
             © {new Date().getFullYear()} Trust Access. {t('footer.rights')}
           </p>
           <div className='flex space-x-6 mt-4 md:mt-0'>
-            <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
+            <Link href='#' className='text-muted-foreground hover:text-white text-sm transition-colors'>
               {t('footer.privacy')}
             </Link>
-            <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
+            <Link href='#' className='text-muted-foreground hover:text-white text-sm transition-colors'>
               {t('footer.terms')}
             </Link>
-            <Link href='#' className='text-gray-400 hover:text-white text-sm transition-colors'>
+            <Link href='#' className='text-muted-foreground hover:text-white text-sm transition-colors'>
               {t('footer.lgpd')}
             </Link>
           </div>

--- a/components/organisms/header.tsx
+++ b/components/organisms/header.tsx
@@ -18,7 +18,7 @@ import { useI18n } from "@/lib/i18n";
 export default function Header() {
   const { t } = useI18n();
   return (
-    <header className="sticky top-0 z-50 w-full border-b bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/60">
+    <header className="sticky top-0 z-50 w-full border-b border-border bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-16 items-center justify-between px-4 md:px-6">
         <div className="flex items-center space-x-3">
           <Image
@@ -38,7 +38,7 @@ export default function Header() {
             <Link
               key={href}
               href={href}
-              className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
+              className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
             >
               {t(label)}
             </Link>
@@ -65,7 +65,7 @@ export default function Header() {
                   <SheetClose asChild key={href}>
                     <Link
                       href={href}
-                      className="text-sm font-medium text-gray-600 transition-colors hover:text-gray-900"
+                      className="text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
                     >
                       {t(label)}
                     </Link>

--- a/components/organisms/hero.tsx
+++ b/components/organisms/hero.tsx
@@ -8,7 +8,7 @@ export default function Hero() {
   return (
     <section className='relative py-20 md:py-32 overflow-hidden'>
       {/* Geometric Background Pattern */}
-      <div className='absolute inset-0 bg-gradient-to-br from-teal-50 via-blue-50 to-cyan-100'>
+      <div className='absolute inset-0 bg-gradient-to-br from-teal-50 via-blue-50 to-cyan-100 dark:from-teal-900 dark:via-blue-900 dark:to-cyan-950'>
         <div className='absolute inset-0 opacity-30'>
           <svg className='w-full h-full' viewBox='0 0 1200 800' fill='none'>
             <defs>
@@ -22,23 +22,23 @@ export default function Hero() {
                 />
               </pattern>
             </defs>
-            <rect width='100%' height='100%' fill='url(#hexagons)' className='text-teal-300' />
+            <rect width='100%' height='100%' fill='url(#hexagons)' className='text-teal-300 dark:text-teal-800' />
           </svg>
         </div>
       </div>
       <div className='container relative px-4 md:px-6'>
         <div className='max-w-4xl'>
           <div className='space-y-8'>
-              <h1 className='text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl text-gray-900'>
+              <h1 className='text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl lg:text-7xl text-foreground'>
                 {t('hero.title')}{' '}
                 <span className='bg-gradient-to-r from-teal-500 to-blue-600 bg-clip-text text-transparent'>
                   {t('hero.highlight')}
                 </span>
               </h1>
-              <p className='text-xl text-gray-600 max-w-3xl leading-relaxed'>
+              <p className='text-xl text-muted-foreground max-w-3xl leading-relaxed'>
                 {t('hero.description1')}
               </p>
-              <p className='text-lg text-gray-700 max-w-3xl leading-relaxed'>
+              <p className='text-lg text-muted-foreground max-w-3xl leading-relaxed'>
                 {t('hero.description2')}
               </p>
               <div className='pt-4'>

--- a/components/organisms/services-section.tsx
+++ b/components/organisms/services-section.tsx
@@ -25,24 +25,24 @@ export default function ServicesSection() {
         <div className='grid gap-16 lg:grid-cols-2 items-center'>
           <div className='space-y-8'>
             <div className='space-y-6'>
-              <h3 className='text-3xl font-bold text-gray-900'>
+              <h3 className='text-3xl font-bold text-foreground'>
                 {t('services.title')}
               </h3>
-              <p className='text-lg text-gray-600 leading-relaxed'>
+              <p className='text-lg text-muted-foreground leading-relaxed'>
                 {t('services.description')}
               </p>
             </div>
           </div>
           <div className='relative'>
-            <div className='bg-gradient-to-br from-blue-100 via-purple-50 to-pink-100 rounded-3xl p-8 relative overflow-hidden'>
+            <div className='bg-gradient-to-br from-blue-100 via-purple-50 to-pink-100 dark:from-blue-900 dark:via-purple-900 dark:to-pink-900 rounded-3xl p-8 relative overflow-hidden'>
               {/* Mock Interface */}
-              <div className='bg-white rounded-lg shadow-lg p-6 space-y-4'>
+              <div className='bg-card rounded-lg shadow-lg p-6 space-y-4'>
                 <div className='flex items-center space-x-3 mb-6'>
                   <div className='w-8 h-8 bg-blue-500 rounded-full flex items-center justify-center'>
                     <Users className='w-4 h-4 text-white' />
                   </div>
                   <div className='flex-1'>
-                    <div className='text-sm text-gray-500'>{t('common.to')}</div>
+                    <div className='text-sm text-muted-foreground'>{t('common.to')}</div>
                     <div className='font-medium'>admin@empresa.com.br</div>
                   </div>
                   <Button size='sm' variant='ghost'>
@@ -54,20 +54,20 @@ export default function ServicesSection() {
                     <Users className='w-4 h-4 text-white' />
                   </div>
                   <div className='flex-1'>
-                    <div className='text-sm text-gray-500'>{t('common.from')}</div>
+                    <div className='text-sm text-muted-foreground'>{t('common.from')}</div>
                     <div className='font-medium'>contato@trustaccess.com.br</div>
                   </div>
                   <Button size='sm' variant='ghost'>
                     <span className='text-red-500'>×</span>
                   </Button>
                 </div>
-                <div className='bg-blue-50 rounded-lg p-4 space-y-3'>
+                <div className='bg-muted rounded-lg p-4 space-y-3'>
                   <div className='flex items-center justify-between'>
                     <span className='text-sm font-medium text-blue-700'>{t('services.messageOptions')}</span>
                     <div className='flex items-center space-x-2'>
                       <span className='text-xs text-blue-600'>{t('common.protection')}</span>
                       <div className='w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                       <span className='text-xs font-medium text-blue-600'>{t('common.on')}</span>
                     </div>
@@ -77,14 +77,14 @@ export default function ServicesSection() {
                       <Shield className='w-4 h-4 text-blue-500' />
                       <span className='text-sm'>{t('services.disableForwarding')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Users className='w-4 h-4 text-blue-500' />
                       <span className='text-sm'>{t('services.expirationDate')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                   </div>
@@ -100,21 +100,21 @@ export default function ServicesSection() {
                       </SelectContent>
                     </Select>
                   </div>
-                  <div className='text-xs text-gray-500'>14/7/2024 @ 10:04 AM</div>
+                  <div className='text-xs text-muted-foreground'>14/7/2024 @ 10:04 AM</div>
                   <div className='border-t pt-3 space-y-2'>
                     <div className='text-sm font-medium text-blue-700'>{t('services.attachmentOptions')}</div>
                     <div className='flex items-center space-x-2'>
                       <Lock className='w-4 h-4 text-blue-500' />
                       <span className='text-sm'>{t('common.watermark')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                     <div className='flex items-center space-x-2'>
                       <Shield className='w-4 h-4 text-blue-500' />
                       <span className='text-sm'>{t('services.persistentProtection')}</span>
                       <div className='ml-auto w-8 h-4 bg-blue-500 rounded-full relative'>
-                        <div className='w-3 h-3 bg-white rounded-full absolute right-0.5 top-0.5'></div>
+                        <div className='w-3 h-3 bg-background rounded-full absolute right-0.5 top-0.5'></div>
                       </div>
                     </div>
                   </div>

--- a/components/organisms/testimonials-section.tsx
+++ b/components/organisms/testimonials-section.tsx
@@ -6,22 +6,22 @@ import { testimonials } from '@/data/testimonials';
 export default function TestimonialsSection() {
   const [primary, secondary] = testimonials;
   return (
-    <section id='cases' className='py-20 md:py-32 bg-gray-50'>
+    <section id='cases' className='py-20 md:py-32 bg-background'>
       <div className='container px-4 md:px-6'>
         <div className='grid gap-12 lg:grid-cols-2'>
-          <Card className='border-0 shadow-lg bg-white'>
+          <Card className='border-0 shadow-lg bg-card'>
             <CardContent className='p-8'>
               <div className='space-y-6'>
-                <div className='text-2xl font-bold text-gray-400 tracking-wider'>
+                <div className='text-2xl font-bold text-muted-foreground tracking-wider'>
                   {primary.company}
                 </div>
-                <blockquote className='text-lg text-gray-700 leading-relaxed'>
+                <blockquote className='text-lg text-muted-foreground leading-relaxed'>
                   {primary.quote}
                 </blockquote>
                 <div className='pt-4'>
-                  <div className='font-semibold text-gray-900'>{primary.name}</div>
-                  <div className='text-gray-600'>{primary.role}</div>
-                  <div className='text-gray-500'>{primary.companyTag}</div>
+                  <div className='font-semibold text-foreground'>{primary.name}</div>
+                  <div className='text-muted-foreground'>{primary.role}</div>
+                  <div className='text-muted-foreground'>{primary.companyTag}</div>
                 </div>
                 <Link
                   href={primary.link}
@@ -46,20 +46,20 @@ export default function TestimonialsSection() {
                 />
               )}
             </div>
-            <Card className='border-0 shadow-lg bg-white'>
+            <Card className='border-0 shadow-lg bg-card'>
               <CardContent className='p-6'>
                 <div className='space-y-4'>
                   <div className='flex items-center space-x-3'>
                     <div className='text-xl font-bold text-blue-600'>{secondary.company}</div>
                   </div>
                   {secondary.heading && (
-                    <h4 className='text-lg font-semibold text-gray-900'>{secondary.heading}</h4>
+                    <h4 className='text-lg font-semibold text-foreground'>{secondary.heading}</h4>
                   )}
-                  <blockquote className='text-gray-700'>{secondary.quote}</blockquote>
+                  <blockquote className='text-muted-foreground'>{secondary.quote}</blockquote>
                   <div className='pt-2'>
-                    <div className='font-semibold text-gray-900'>{secondary.name}</div>
-                    <div className='text-gray-600'>{secondary.role}</div>
-                    <div className='text-gray-500'>{secondary.companyTag}</div>
+                    <div className='font-semibold text-foreground'>{secondary.name}</div>
+                    <div className='text-muted-foreground'>{secondary.role}</div>
+                    <div className='text-muted-foreground'>{secondary.companyTag}</div>
                   </div>
                   <Link
                     href={secondary.link}

--- a/components/organisms/trust-section.tsx
+++ b/components/organisms/trust-section.tsx
@@ -5,10 +5,10 @@ import { useI18n } from '@/lib/i18n';
 export default function TrustSection() {
   const { t } = useI18n();
   return (
-    <section className='py-16 bg-gradient-to-r from-teal-50 to-blue-50'>
+    <section className='py-16 bg-gradient-to-r from-teal-50 to-blue-50 dark:from-teal-900 dark:to-blue-900'>
       <div className='container px-4 md:px-6'>
         <div className='text-center space-y-8'>
-          <p className='text-lg font-medium text-gray-700 uppercase tracking-wide'>
+          <p className='text-lg font-medium text-muted-foreground uppercase tracking-wide'>
             {t('trust.before')}{' '}
             <span className='font-bold text-2xl bg-gradient-to-r from-teal-600 to-blue-600 bg-clip-text text-transparent'>
               {t('trust.highlight')}
@@ -17,16 +17,16 @@ export default function TrustSection() {
           </p>
           <div className='grid grid-cols-2 md:grid-cols-4 gap-8 items-center opacity-60'>
             <div className='flex items-center justify-center'>
-              <div className='text-2xl font-bold text-gray-500'>MINING</div>
+              <div className='text-2xl font-bold text-muted-foreground'>MINING</div>
             </div>
             <div className='flex items-center justify-center'>
-              <div className='text-2xl font-bold text-gray-500'>CLIENT</div>
+              <div className='text-2xl font-bold text-muted-foreground'>CLIENT</div>
             </div>
             <div className='flex items-center justify-center'>
-              <div className='text-2xl font-bold text-gray-500'>ULTIMATE</div>
+              <div className='text-2xl font-bold text-muted-foreground'>ULTIMATE</div>
             </div>
             <div className='flex items-center justify-center'>
-              <div className='text-2xl font-bold text-gray-500'>ENTERPRISE</div>
+              <div className='text-2xl font-bold text-muted-foreground'>ENTERPRISE</div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- replace hardcoded light colors with theme-aware tokens
- add dark mode gradient variants and semantic text colors
- apply dark theme styles to forms and footer

## Testing
- `pnpm exec vitest run --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_689697243cd88330b53b0b42cb931530