### PR TITLE
test: add coverage and component tests

### DIFF
--- a/components/molecules/__tests__/demo-form.test.tsx
+++ b/components/molecules/__tests__/demo-form.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@/test/test-utils';
+import DemoForm from '../demo-form';
+
+describe('DemoForm', () => {
+  it('renders the demo form heading', () => {
+    render(<DemoForm />);
+    expect(screen.getByText('Agendar uma Demo')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/audit-section.test.tsx
+++ b/components/organisms/__tests__/audit-section.test.tsx
@@ -1,0 +1,10 @@
+import AuditSection from '../audit-section';
+import { render, screen } from '@/test/test-utils';
+
+describe('AuditSection', () => {
+  it('renders audit content', () => {
+    render(<AuditSection />);
+    expect(screen.getByText('audit.title')).toBeInTheDocument();
+    expect(screen.getByText('audit.description')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/clients-section.test.tsx
+++ b/components/organisms/__tests__/clients-section.test.tsx
@@ -1,0 +1,13 @@
+import { render, screen } from '@/test/test-utils';
+import ClientsSection from '../clients-section';
+import { clientCases } from '@/data/client-cases';
+
+describe('ClientsSection', () => {
+  it('renders clients heading and cases', () => {
+    render(<ClientsSection />);
+    expect(screen.getByText('clients.heading')).toBeInTheDocument();
+    clientCases.forEach(({ heading }) => {
+      expect(screen.getByText(heading)).toBeInTheDocument();
+    });
+  });
+});

--- a/components/organisms/__tests__/compliance-section.test.tsx
+++ b/components/organisms/__tests__/compliance-section.test.tsx
@@ -1,0 +1,10 @@
+import ComplianceSection from '../compliance-section';
+import { render, screen } from '@/test/test-utils';
+
+describe('ComplianceSection', () => {
+  it('renders compliance content', () => {
+    render(<ComplianceSection />);
+    expect(screen.getByText('compliance.title')).toBeInTheDocument();
+    expect(screen.getByText('compliance.description')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/footer.test.tsx
+++ b/components/organisms/__tests__/footer.test.tsx
@@ -1,0 +1,11 @@
+import Footer from '../footer';
+import { render, screen } from '@/test/test-utils';
+
+describe('Footer', () => {
+  it('renders footer content', () => {
+    render(<Footer />);
+    expect(screen.getByText('footer.tagline')).toBeInTheDocument();
+    expect(screen.getByText('footer.services')).toBeInTheDocument();
+    expect(screen.getByText('footer.company')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/hero.test.tsx
+++ b/components/organisms/__tests__/hero.test.tsx
@@ -1,0 +1,10 @@
+import Hero from '../hero';
+import { render, screen } from '@/test/test-utils';
+
+describe('Hero', () => {
+  it('renders hero content', () => {
+    render(<Hero />);
+    expect(screen.getByText('hero.title')).toBeInTheDocument();
+    expect(screen.getByText('hero.cta')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/services-section.test.tsx
+++ b/components/organisms/__tests__/services-section.test.tsx
@@ -1,0 +1,11 @@
+import ServicesSection from '../services-section';
+import { render, screen } from '@/test/test-utils';
+
+describe('ServicesSection', () => {
+  it('renders services content', () => {
+    render(<ServicesSection />);
+    expect(screen.getByText('services.intro')).toBeInTheDocument();
+    expect(screen.getByText('services.title')).toBeInTheDocument();
+    expect(screen.getByText('services.description')).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/testimonials-section.test.tsx
+++ b/components/organisms/__tests__/testimonials-section.test.tsx
@@ -1,0 +1,11 @@
+import { render, screen } from '@/test/test-utils';
+import TestimonialsSection from '../testimonials-section';
+import { testimonials } from '@/data/testimonials';
+
+describe('TestimonialsSection', () => {
+  it('renders testimonials data', () => {
+    render(<TestimonialsSection />);
+    expect(screen.getByText(testimonials[0].quote)).toBeInTheDocument();
+    expect(screen.getByText(testimonials[1].quote)).toBeInTheDocument();
+  });
+});

--- a/components/organisms/__tests__/trust-section.test.tsx
+++ b/components/organisms/__tests__/trust-section.test.tsx
@@ -1,0 +1,10 @@
+import TrustSection from '../trust-section';
+import { render, screen } from '@/test/test-utils';
+
+describe('TrustSection', () => {
+  it('renders trust content', () => {
+    render(<TrustSection />);
+    expect(screen.getByText('trust.before', { exact: false })).toBeInTheDocument();
+    expect(screen.getByText('trust.highlight')).toBeInTheDocument();
+  });
+});

--- a/hooks/__tests__/use-toast.test.ts
+++ b/hooks/__tests__/use-toast.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react';
+import { useToast } from '@/hooks/use-toast';
+import { vi } from 'vitest';
+
+describe('useToast', () => {
+  it('adds, updates, and dismisses toasts', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useToast());
+    let controller: { id: string; dismiss: () => void; update: (props: { id: string; title?: string }) => void };
+    act(() => {
+      controller = result.current.toast({ title: 'Hello' });
+    });
+    expect(result.current.toasts).toHaveLength(1);
+    act(() => {
+      controller.update({ id: controller.id, title: 'Updated' });
+    });
+    expect(result.current.toasts[0].title).toBe('Updated');
+    act(() => {
+      controller.dismiss();
+    });
+    expect(result.current.toasts[0].open).toBe(false);
+    vi.runAllTimers();
+    expect(result.current.toasts).toHaveLength(0);
+    vi.useRealTimers();
+  });
+});

--- a/test/test-utils.tsx
+++ b/test/test-utils.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { vi } from 'vitest';
+import * as testing from '@testing-library/react';
+
+// Mock Next.js components and i18n hook used in many components
+vi.mock('next/image', () => ({
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  },
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...rest }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { href: string; children: React.ReactNode }) => (
+    <a href={href} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/lib/i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+
+export const { render, screen, fireEvent, waitFor } = testing;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,12 @@ export default defineConfig({
     include: ['**/*.{test,spec}.tsx'],
     coverage: {
       provider: 'v8',
+      thresholds: {
+        statements: 0.8,
+        branches: 0.8,
+        functions: 0.8,
+        lines: 0.8,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- add unit tests for homepage sections and demo form
- cover toast hook and configure coverage thresholds
- provide shared test utilities for mocking Next.js components

## Testing
- `CI=1 pnpm test -- --coverage`


------
https://chatgpt.com/codex/tasks/task_e_689a622729e4833095e79745f4b187e6