### PR TITLE
feat: add i18n configuration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -79,12 +79,13 @@ export const viewport: Viewport = {
   themeColor: "#0A0A0A",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const locale = cookies().get("NEXT_LOCALE")?.value || "pt";
+  const cookieStore = await cookies();
+  const locale = cookieStore.get("NEXT_LOCALE")?.value || "pt";
   return (
     <html lang={locale}>
       <body className={inter.className}>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { siteConfig } from "@/lib/config";
 import { QueryProvider } from "@/components/templates/query-provider";
 import { I18nProvider } from "@/lib/i18n";
 import { ThemeProvider } from "@/components/templates/theme-provider";
+import { cookies } from "next/headers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -27,6 +28,14 @@ export const metadata: Metadata = {
     siteConfig.name,
   ],
   metadataBase: new URL(siteConfig.url),
+  alternates: {
+    canonical: "/",
+    languages: {
+      en: "/en",
+      es: "/es",
+      pt: "/",
+    },
+  },
   openGraph: {
     title: `${siteConfig.name} | Identity & Access Management`,
     description:
@@ -75,8 +84,9 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const locale = cookies().get("NEXT_LOCALE")?.value || "pt";
   return (
-    <html lang="pt">
+    <html lang={locale}>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <I18nProvider>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,6 +15,10 @@ const nextConfig = {
       },
     ],
   },
+  i18n: {
+    locales: ['en', 'es', 'pt'],
+    defaultLocale: 'pt',
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
- configure i18n locales and default locale in Next.js config
- add alternate language metadata and dynamic HTML lang attribute

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689a70661c0c833094788f72c37bf8be