### PR TITLE
feat: add organization json-ld

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -86,8 +86,42 @@ export default async function RootLayout({
 }) {
   const cookieStore = await cookies();
   const locale = cookieStore.get("NEXT_LOCALE")?.value || "pt";
+  const organizationJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: siteConfig.name,
+    url: siteConfig.url,
+    logo: `${siteConfig.url}/placeholder-logo.svg`,
+    contactPoint: [
+      {
+        "@type": "ContactPoint",
+        email: "contato@trustaccess.com.br",
+        contactType: "customer service",
+      },
+    ],
+  };
+  const websiteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    url: siteConfig.url,
+    name: siteConfig.name,
+  };
   return (
     <html lang={locale}>
+      <head>
+        <script
+          id="organization-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify(organizationJsonLd),
+          }}
+        />
+        <script
+          id="website-jsonld"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteJsonLd) }}
+        />
+      </head>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           <I18nProvider>


### PR DESCRIPTION
## Summary
- inject organization schema and website structured data in root layout

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_689a7624fc608330a35e2aedf52ac8e3