### PR TITLE
feat: add error boundary page

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,20 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/atoms/ui/button';
+
+export default function Error({ error }: { error: Error & { digest?: string } }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-background p-6 text-center">
+      <h1 className="mb-4 text-4xl font-bold">Something went wrong</h1>
+      <Button onClick={() => router.refresh()}>Try again</Button>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add `app/error.tsx` to handle runtime errors with refresh button

## Testing
- `pnpm lint`
- `CI=1 pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_689a830406548330aaa8c18234b65ebc