### PR TITLE
feat: add loading skeleton

### DIFF
--- a/app/loading.tsx
+++ b/app/loading.tsx
@@ -1,0 +1,9 @@
+import { Skeleton } from "@/components/atoms/ui/skeleton";
+
+export default function Loading() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-4">
+      <Skeleton className="h-8 w-8 rounded-full" />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `app/loading.tsx` to show a skeleton while server content streams

## Testing
- `pnpm lint`
- `pnpm test run`

------
https://chatgpt.com/codex/tasks/task_e_689a8fe331b0833095ec72ae1ff2b828