### PR TITLE
Fix automatic redirect to unsupported /en route

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -18,6 +18,9 @@ const nextConfig = {
   i18n: {
     locales: ['en', 'es', 'pt'],
     defaultLocale: 'pt',
+    // Disable automatic locale detection to prevent redirects to
+    // unsupported language routes like "/en" that result in 404s.
+    localeDetection: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- disable Next.js automatic locale detection to stop redirects to `/en`

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689a92bc11888330a84640099d8fc639