### PR TITLE
Refactor locale page parameters

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,0 +1,17 @@
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+const supportedLocales = ["en", "es", "pt"];
+
+interface LocaleParams {
+  params: { locale: string };
+}
+
+export default function LocalePage({ params: { locale } }: LocaleParams) {
+  if (!supportedLocales.includes(locale)) {
+    redirect("/");
+  }
+
+  cookies().set("NEXT_LOCALE", locale);
+  redirect("/");
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -4,10 +4,12 @@ import { redirect } from "next/navigation";
 const supportedLocales = ["en", "es", "pt"];
 
 interface LocaleParams {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }
 
-export default function LocalePage({ params: { locale } }: LocaleParams) {
+export default async function LocalePage({ params }: LocaleParams) {
+  const { locale } = await params;
+
   if (!supportedLocales.includes(locale)) {
     redirect("/");
   }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -14,6 +14,7 @@ export default async function LocalePage({ params }: LocaleParams) {
     redirect("/");
   }
 
-  cookies().set("NEXT_LOCALE", locale);
+  const cookieStore = await cookies();
+  cookieStore.set("NEXT_LOCALE", locale);
   redirect("/");
 }


### PR DESCRIPTION
## Summary
- add locale parameter interface for dynamic route
- simplify locale page by destructuring params and keeping redirect and cookie logic

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_689aa2c64cfc8330854e20d07077041e