### PR TITLE
Add locale-aware routing and sync language switcher

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import HomePage from "../page";
 
 const supportedLocales = ["en", "es", "pt"];
 
@@ -16,5 +17,6 @@ export default async function LocalePage({ params }: LocaleParams) {
 
   const cookieStore = await cookies();
   cookieStore.set("NEXT_LOCALE", locale);
-  redirect("/");
+
+  return <HomePage />;
 }

--- a/components/atoms/language-switcher/__tests__/LanguageSwitcher.test.tsx
+++ b/components/atoms/language-switcher/__tests__/LanguageSwitcher.test.tsx
@@ -3,10 +3,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import LanguageSwitcher from "@/components/atoms/language-switcher";
 import { I18nProvider } from "@/lib/i18n";
+import { routerPush } from "@/vitest.setup";
 
 describe("LanguageSwitcher", () => {
   beforeEach(() => {
     localStorage.clear();
+    routerPush.mockClear();
   });
 
   it("allows keyboard navigation to change language", async () => {
@@ -25,6 +27,7 @@ describe("LanguageSwitcher", () => {
     await screen.findByText("English");
     expect(trigger).toHaveTextContent("English");
     expect(localStorage.getItem("locale")).toBe("en");
+    expect(routerPush).toHaveBeenCalledWith("/en");
   });
 
   it("renders options with accessible labels", async () => {

--- a/components/atoms/language-switcher/index.tsx
+++ b/components/atoms/language-switcher/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Locale, useI18n } from "@/lib/i18n";
+import { useRouter } from "next/navigation";
 import {
   Select,
   SelectTrigger,
@@ -18,6 +19,7 @@ export default function LanguageSwitcher({
   className,
 }: LanguageSwitcherProps) {
   const { t, locale, setLocale } = useI18n();
+  const router = useRouter();
   const languages: { value: Locale; label: string; flag: string }[] = [
     { value: "en", label: t("languages.en"), flag: "🇺🇸" },
     { value: "es", label: t("languages.es"), flag: "🇪🇸" },
@@ -25,7 +27,13 @@ export default function LanguageSwitcher({
   ];
 
   return (
-    <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
+    <Select
+      value={locale}
+      onValueChange={(v) => {
+        setLocale(v as Locale);
+        router.push(`/${v}`);
+      }}
+    >
       <SelectTrigger className={cn("w-full md:w-[120px]", className)}>
         <SelectValue />
       </SelectTrigger>

--- a/lib/i18n/index.tsx
+++ b/lib/i18n/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 
 export type Locale = "en" | "es" | "pt";
 
@@ -40,16 +41,24 @@ const loaders: Record<
   pt: () => import("./pt.json"),
 };
 
+const SUPPORTED_LOCALES: Locale[] = ["en", "es", "pt"];
+
 export function I18nProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocale] = useState<Locale>("pt");
+  const pathname = usePathname();
+  const pathLocale = pathname?.split("/")[1];
+  const [locale, setLocale] = useState<Locale>(
+    SUPPORTED_LOCALES.includes(pathLocale as Locale)
+      ? (pathLocale as Locale)
+      : "pt",
+  );
   const [dictionary, setDictionary] = useState<Record<string, unknown>>({});
 
   useEffect(() => {
-    const storedLocale = localStorage.getItem("locale") as Locale | null;
-    if (storedLocale) {
-      setLocale(storedLocale);
+    const current = pathname?.split("/")[1];
+    if (SUPPORTED_LOCALES.includes(current as Locale) && current !== locale) {
+      setLocale(current as Locale);
     }
-  }, []);
+  }, [pathname, locale]);
 
   useEffect(() => {
     loaders[locale]().then((module) => setDictionary(module.default));

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,20 @@
 import "@testing-library/jest-dom";
+import { vi } from "vitest";
+
+let currentPath = "/pt";
+export const routerPush = vi.fn((path: string) => {
+  currentPath = path;
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  usePathname: () => currentPath,
+}));
+
+beforeEach(() => {
+  routerPush.mockClear();
+  currentPath = "/pt";
+});
 
 // Polyfills for Radix UI components in JSDOM
 window.HTMLElement.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
## Summary
- render landing page on `/[locale]` and persist locale cookie
- push to locale routes and sync language switcher with URL
- derive app locale from current pathname and mock router in tests

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_689ab1caf9b083309b2982380817d5c8