### PR TITLE
Add locale-aware routing and sync language switcher

### DIFF
--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,5 +1,5 @@
-import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
+import HomePage from "../page";
 
 const supportedLocales = ["en", "es", "pt"];
 
@@ -13,8 +13,5 @@ export default async function LocalePage({ params }: LocaleParams) {
   if (!supportedLocales.includes(locale)) {
     redirect("/");
   }
-
-  const cookieStore = await cookies();
-  cookieStore.set("NEXT_LOCALE", locale);
-  redirect("/");
+  return <HomePage />;
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,7 +1,8 @@
 import { redirect } from "next/navigation";
 import HomePage from "../page";
 
-const supportedLocales = ["en", "es", "pt"];
+const SUPPORTED_LOCALES = ["en", "es", "pt"] as const;
+type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
 
 interface LocaleParams {
   params: Promise<{ locale: string }>;
@@ -10,7 +11,7 @@ interface LocaleParams {
 export default async function LocalePage({ params }: LocaleParams) {
   const { locale } = await params;
 
-  if (!supportedLocales.includes(locale)) {
+  if (!SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
     redirect("/");
   }
   return <HomePage />;

--- a/components/atoms/language-switcher/__tests__/LanguageSwitcher.test.tsx
+++ b/components/atoms/language-switcher/__tests__/LanguageSwitcher.test.tsx
@@ -3,10 +3,12 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import LanguageSwitcher from "@/components/atoms/language-switcher";
 import { I18nProvider } from "@/lib/i18n";
+import { routerPush } from "@/vitest.setup";
 
 describe("LanguageSwitcher", () => {
   beforeEach(() => {
     localStorage.clear();
+    routerPush.mockClear();
   });
 
   it("allows keyboard navigation to change language", async () => {
@@ -25,6 +27,7 @@ describe("LanguageSwitcher", () => {
     await screen.findByText("English");
     expect(trigger).toHaveTextContent("English");
     expect(localStorage.getItem("locale")).toBe("en");
+    expect(routerPush).toHaveBeenCalledWith("/en");
   });
 
   it("renders options with accessible labels", async () => {

--- a/components/atoms/language-switcher/index.tsx
+++ b/components/atoms/language-switcher/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Locale, useI18n } from "@/lib/i18n";
+import { useRouter } from "next/navigation";
 import {
   Select,
   SelectTrigger,
@@ -18,6 +19,7 @@ export default function LanguageSwitcher({
   className,
 }: LanguageSwitcherProps) {
   const { t, locale, setLocale } = useI18n();
+  const router = useRouter();
   const languages: { value: Locale; label: string; flag: string }[] = [
     { value: "en", label: t("languages.en"), flag: "🇺🇸" },
     { value: "es", label: t("languages.es"), flag: "🇪🇸" },
@@ -25,7 +27,13 @@ export default function LanguageSwitcher({
   ];
 
   return (
-    <Select value={locale} onValueChange={(v) => setLocale(v as Locale)}>
+    <Select
+      value={locale}
+      onValueChange={(v) => {
+        setLocale(v as Locale);
+        router.push(`/${v}`);
+      }}
+    >
       <SelectTrigger className={cn("w-full md:w-[120px]", className)}>
         <SelectValue />
       </SelectTrigger>

--- a/lib/i18n/index.tsx
+++ b/lib/i18n/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React, { createContext, useContext, useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
 
 export type Locale = "en" | "es" | "pt";
 
@@ -40,16 +41,24 @@ const loaders: Record<
   pt: () => import("./pt.json"),
 };
 
+const SUPPORTED_LOCALES: Locale[] = ["en", "es", "pt"];
+
 export function I18nProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocale] = useState<Locale>("pt");
+  const pathname = usePathname();
+  const pathLocale = pathname?.split("/")[1];
+  const [locale, setLocale] = useState<Locale>(
+    SUPPORTED_LOCALES.includes(pathLocale as Locale)
+      ? (pathLocale as Locale)
+      : "pt",
+  );
   const [dictionary, setDictionary] = useState<Record<string, unknown>>({});
 
   useEffect(() => {
-    const storedLocale = localStorage.getItem("locale") as Locale | null;
-    if (storedLocale) {
-      setLocale(storedLocale);
+    const current = pathname?.split("/")[1];
+    if (SUPPORTED_LOCALES.includes(current as Locale) && current !== locale) {
+      setLocale(current as Locale);
     }
-  }, []);
+  }, [pathname, locale]);
 
   useEffect(() => {
     loaders[locale]().then((module) => setDictionary(module.default));

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,9 +2,17 @@ import { NextRequest, NextResponse } from "next/server";
 
 const SUPPORTED_LOCALES = ["en", "es", "pt"] as const;
 type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+const DEFAULT_LOCALE: SupportedLocale = "pt";
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const pathLocale = pathname.split("/")[1];
+
+  if (SUPPORTED_LOCALES.includes(pathLocale as SupportedLocale)) {
+    const response = NextResponse.next();
+    response.cookies.set("NEXT_LOCALE", pathLocale);
+    return response;
+  }
 
   const cookieLocale = request.cookies
     .get("NEXT_LOCALE")
@@ -16,13 +24,14 @@ export function middleware(request: NextRequest) {
     ?.split("-")[0]
     ?.toLowerCase();
 
-  const locale = cookieLocale || headerLocale;
-
-  if (!locale || !SUPPORTED_LOCALES.includes(locale as SupportedLocale)) {
-    if (pathname !== "/") {
-      return NextResponse.redirect(new URL("/", request.url));
-    }
-    return NextResponse.next();
+  let locale: SupportedLocale = DEFAULT_LOCALE;
+  if (cookieLocale && SUPPORTED_LOCALES.includes(cookieLocale as SupportedLocale)) {
+    locale = cookieLocale as SupportedLocale;
+  } else if (
+    headerLocale &&
+    SUPPORTED_LOCALES.includes(headerLocale as SupportedLocale)
+  ) {
+    locale = headerLocale as SupportedLocale;
   }
 
   if (pathname === "/") {
@@ -33,5 +42,5 @@ export function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|en|es|pt).*)"],
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico).*)"],
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -15,13 +15,6 @@ const nextConfig = {
       },
     ],
   },
-  i18n: {
-    locales: ['en', 'es', 'pt'],
-    defaultLocale: 'pt',
-    // Disable automatic locale detection to prevent redirects to
-    // unsupported language routes like "/en" that result in 404s.
-    localeDetection: false,
-  },
 }
 
 export default nextConfig

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,20 @@
 import "@testing-library/jest-dom";
+import { beforeEach, vi } from "vitest";
+
+let currentPath = "/pt";
+export const routerPush = vi.fn((path: string) => {
+  currentPath = path;
+});
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: routerPush }),
+  usePathname: () => currentPath,
+}));
+
+beforeEach(() => {
+  routerPush.mockClear();
+  currentPath = "/pt";
+});
 
 // Polyfills for Radix UI components in JSDOM
 window.HTMLElement.prototype.scrollIntoView = function () {};


### PR DESCRIPTION
## Summary
- remove server-side locale cookie mutation from localized page
- handle locale cookie and root redirects in middleware with default locale fallback
- drop unsupported Next.js i18n config

## Testing
- `pnpm lint`
- `pnpm test run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689ab1caf9b083309b2982380817d5c8