### PR TITLE
refactor locale handling

### DIFF
--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { RootLayoutBase } from "../layout";
+
+export default async function LocaleLayout({
+  children,
+  params,
+}: {
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale: paramLocale } = await params;
+  const cookieStore = await cookies();
+  const cookieLocale = cookieStore.get("NEXT_LOCALE")?.value;
+  const locale = paramLocale || cookieLocale || "pt";
+  return <RootLayoutBase locale={locale}>{children}</RootLayoutBase>;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,7 +5,6 @@ import { siteConfig } from "@/lib/config";
 import { QueryProvider } from "@/components/templates/query-provider";
 import { I18nProvider } from "@/lib/i18n";
 import { ThemeProvider } from "@/components/templates/theme-provider";
-import { cookies } from "next/headers";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -79,13 +78,15 @@ export const viewport: Viewport = {
   themeColor: "#0A0A0A",
 };
 
-export default async function RootLayout({
-  children,
-}: {
+interface RootLayoutProps {
   children: React.ReactNode;
-}) {
-  const cookieStore = await cookies();
-  const locale = cookieStore.get("NEXT_LOCALE")?.value || "pt";
+  locale?: string;
+}
+
+export function RootLayoutBase({
+  children,
+  locale = "pt",
+}: RootLayoutProps) {
   const organizationJsonLd = {
     "@context": "https://schema.org",
     "@type": "Organization",
@@ -131,4 +132,8 @@ export default async function RootLayout({
       </body>
     </html>
   );
+}
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return <RootLayoutBase>{children}</RootLayoutBase>;
 }


### PR DESCRIPTION
## Summary
- decouple locale cookie lookup from root layout
- forward locale to `RootLayout` via props
- add locale-aware layout for `[locale]` routes

## Testing
- `pnpm exec vitest run`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_689b233699a48330ad6d40d44878107d