### PR TITLE
feat: add analytics and web vitals reporting

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from "next";
+import Script from "next/script";
 import "./globals.css";
 import { siteConfig } from "@/lib/config";
 import RootLayoutBase from "./root-layout-base";
@@ -74,5 +75,23 @@ export const viewport: Viewport = {
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return <RootLayoutBase>{children}</RootLayoutBase>;
+  const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+  return (
+    <RootLayoutBase>
+      <Script
+        src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        strategy="afterInteractive"
+      />
+      <Script id="ga-analytics" strategy="afterInteractive">
+        {`
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);} 
+          gtag('js', new Date());
+          gtag('config', '${GA_MEASUREMENT_ID}');
+        `}
+      </Script>
+      {children}
+    </RootLayoutBase>
+  );
 }

--- a/app/reportWebVitals.ts
+++ b/app/reportWebVitals.ts
@@ -1,0 +1,17 @@
+import type { NextWebVitalsMetric } from "next/app";
+
+export function reportWebVitals(metric: NextWebVitalsMetric) {
+  const url = process.env.NEXT_PUBLIC_ANALYTICS_URL ?? "/api/analytics";
+  const body = JSON.stringify(metric);
+
+  if (typeof navigator !== "undefined" && navigator.sendBeacon) {
+    navigator.sendBeacon(url, body);
+  } else {
+    fetch(url, {
+      body,
+      method: "POST",
+      keepalive: true,
+      headers: { "Content-Type": "application/json" },
+    }).catch(console.error);
+  }
+}


### PR DESCRIPTION
## Summary
- add Google Analytics Script to root layout
- forward Next.js web vitals to analytics endpoint

## Testing
- `pnpm exec eslint app/layout.tsx app/reportWebVitals.ts && echo 'lint completed'`
- `pnpm test --run`
- `node -e "process.env.NEXT_PUBLIC_ANALYTICS_URL='https://example.com/analytics'; const { reportWebVitals } = require('/tmp/rwv/reportWebVitals.js'); global.fetch=(url,options)=>{console.log('fetch called',url,'body',options.body); return Promise.resolve({status:200});}; reportWebVitals({id:'1', name:'LCP', label:'web-vital', value:123, startTime:0});"`

------
https://chatgpt.com/codex/tasks/task_e_689b4ce02b6083308d4cb84f446e3770