### PR TITLE
feat: prioritize logo image

### DIFF
--- a/components/organisms/header/index.tsx
+++ b/components/organisms/header/index.tsx
@@ -32,7 +32,7 @@ export default async function Header() {
             width={32}
             height={32}
             className="h-8 w-8"
-            loading="lazy"
+            priority
           />
           <span className="bg-gradient-to-r from-teal-500 to-blue-600 bg-clip-text text-2xl font-bold text-transparent">
             Trust Access


### PR DESCRIPTION
## Summary
- mark header logo image with `priority`
- confirmed remaining images stay lazily loaded

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_689b58061ac083309173cdf4eec6bf3a